### PR TITLE
fix #37: Update README for 2.0 core-only scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,30 +3,45 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/artisanpackui/security.svg?style=flat-square)](https://packagist.org/packages/artisanpackui/security)
 [![Total Downloads](https://img.shields.io/packagist/dt/artisanpackui/security.svg?style=flat-square)](https://packagist.org/packages/artisanpackui/security)
 
-A comprehensive security package for Laravel applications, specifically designed for the Digital Shopfront CMS. This package provides essential data sanitization and output escaping functions to protect against common web vulnerabilities like XSS attacks, SQL injection, and data corruption.
+> **IMPORTANT**: This is the **2.0 core-only** version of ArtisanPack Security. 
+> For the full package with all features, see [artisanpackui/security-full](https://packagist.org/packages/artisanpackui/security-full).
 
-## Features
+A lightweight, focused security package for Laravel applications providing essential core security utilities: input sanitization, output escaping, KSES HTML filtering, CSP headers, and security headers middleware.
 
-- **Comprehensive Sanitization**: Clean user input with specialized functions for emails, URLs, text, dates, and more
-- **Context-Aware Escaping**: Safely escape output for HTML, attributes, URLs, JavaScript, and CSS contexts
-- **HTML Filtering**: WordPress-style HTML filtering with `kses()` function
-- **Laravel Integration**: Facade and global helper functions for easy usage
-- **Battle-Tested**: Built on proven libraries like Laminas Escaper
-- **Full Test Coverage**: Extensively tested for reliability
+## What's New in 2.0
+
+Version 2.0 focuses on core security utilities only. Some features have been moved to separate packages:
+
+| Feature | New Package |
+|---------|-------------|
+| Two-Factor Authentication | `artisanpackui/2fa` |
+| Role-Based Access Control | `artisanpackui/rbac` |
+| File Upload Security | `artisanpackui/file-upload` |
+| Security Analytics | `artisanpackui/analytics` |
+| Compliance Tools | `artisanpackui/compliance` |
+| Advanced Auth | `artisanpackui/advanced-auth` |
+
+Want everything? Install the [meta-package](https://packagist.org/packages/artisanpackui/security-full):
+
+```bash
+composer require artisanpackui/security-full
+```
+
+## Core Features
+
+- **Input Sanitization**: Clean user input (emails, URLs, text, integers, arrays)
+- **Context-Aware Escaping**: HTML, attributes, URLs, JavaScript, and CSS
+- **KSES HTML Filtering**: WordPress-style HTML filtering with `kses()`
+- **Security Headers**: CSP, X-Frame-Options, X-Content-Type-Options, and more
+
+## Installation
+
+```bash
+composer require artisanpackui/security
+```
 
 ## Quick Start
 
-### Installation
-
-Install the package via Composer:
-
-```bash
-composer require ArtisanPackUI/security
-```
-
-### Basic Usage
-
-Use the Security facade:
 ```php
 use ArtisanPackUI\Security\Facades\Security;
 
@@ -35,39 +50,24 @@ $cleanEmail = Security::sanitizeEmail($userEmail);
 
 // Escape output
 echo Security::escHtml($userContent);
+
+// KSES HTML filtering (allow safe tags)
+$filtered = Security::kses($userHtml, $allowedTags);
+
+// Set security headers
+Security::setContentSecurityPolicy();
 ```
 
-Or use global helper functions:
-```php
-// Sanitize input
-$cleanEmail = sanitizeEmail($userEmail);
+## Available Core Functions
 
-// Escape output
-echo escHtml($userContent);
-```
-
-## Documentation
-
-📚 **[Complete Documentation](docs/home.md)**
-
-- **[Getting Started](docs/getting-started.md)** - Installation, setup, and basic usage
-- **[API Reference](docs/api-reference.md)** - Complete function reference with examples
-- **[Security Guidelines](docs/security-guidelines.md)** - Best practices and security considerations
-- **[AI Guidelines](docs/ai-guidelines.md)** - Guidelines for AI code generation
-- **[Contributing](docs/contributing.md)** - How to contribute to this project
-- **[Changelog](docs/changelog.md)** - Version history and changes
-
-## Available Functions
-
-### Sanitization Functions
+### Sanitization
 - `sanitizeEmail()` - Clean email addresses
-- `sanitizeUrl()` - Sanitize URLs
+- `sanitizeUrl()` - Sanitize URLs  
 - `sanitizeText()` - Remove HTML and clean text
 - `sanitizeInt()` - Convert to safe integers
 - `sanitizeArray()` - Recursively clean arrays
-- And more...
 
-### Escaping Functions
+### Escaping
 - `escHtml()` - HTML context escaping
 - `escAttr()` - HTML attribute escaping
 - `escUrl()` - URL escaping
@@ -77,18 +77,35 @@ echo escHtml($userContent);
 ### HTML Filtering
 - `kses()` - WordPress-style HTML filtering
 
+### Security Headers
+- `setContentSecurityPolicy()` - CSP headers
+- `setXFrameOptions()` - Clickjacking protection
+- `setXContentTypeOptions()` - MIME sniffing protection
+- `setStrictTransportSecurity()` - HSTS headers
+
+## Migration from 1.x
+
+See the [Migration Guide](docs/migration-1x-to-2x.md) for upgrading from version 1.x.
+
+## Documentation
+
+📚 **[Complete Documentation](docs/home.md)**
+
+- **[Getting Started](docs/getting-started.md)** - Installation and setup
+- **[API Reference](docs/api-reference.md)** - Function reference
+- **[Security Guidelines](docs/security-guidelines.md)** - Best practices
+- **[Migration Guide](docs/migration-1x-to-2x.md)** - Upgrade from 1.x
+
+## Related Packages
+
+- [security-full](https://packagist.org/packages/artisanpackui/security-full) - Meta-package with all features
+- [2fa](https://packagist.org/packages/artisanpackui/2fa) - Two-Factor Authentication
+- [rbac](https://packagist.org/packages/artisanpackui/rbac) - Role-Based Access Control
+
 ## Security
 
-If you discover any security vulnerabilities, please follow our [security reporting guidelines](docs/contributing.md#security-contributions). Do not open public issues for security vulnerabilities.
-
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guide](docs/contributing.md) for details on how to contribute to this project.
-
-## About Digital Shopfront CMS
-
-This package is part of the ArtisanPack UI ecosystem for [Digital Shopfront CMS](https://gitlab.com/jacob-martella-web-design/digital-shopfront/digital-shopfront-core/digital-shopfront). Learn more about the full CMS in our [main documentation](https://gitlab.com/jacob-martella-web-design/digital-shopfront/digital-shopfront-core/digital-shopfront/-/wikis/home).
+If you discover security vulnerabilities, please follow our [security reporting guidelines](docs/contributing.md#security-contributions). Do not open public issues.
 
 ## License
 
-This project is open-sourced software licensed under the [MIT license](LICENSE).
+MIT license.


### PR DESCRIPTION
## Summary

Updates README to reflect the 2.0 core-only scope as described in issue #37.

## Changes

- Added 2.0 IMPORTANT notice at top
- Core features limited to: input sanitization, output escaping, KSES HTML filtering, CSP/security headers
- Added feature migration table showing which features moved to separate packages
- Added reference to `security-full` meta-package
- Added migration guide reference
- Simplified feature list

## Acceptance Criteria

- [x] README clearly describes the core-only scope
- [x] Feature list updated to only include core features
- [x] Installation instructions updated for 2.0
- [x] Links to split packages for features that moved out
- [x] Link to `security-full` meta-package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Repositioned ArtisanPack Security 2.0 as core-only package with reference to full feature set via meta-package.
  * Added "What's New in 2.0" section detailing capabilities moved to separate packages.
  * Updated installation instructions and quick start examples with improved code samples.
  * Documented new Security Headers functions and added migration guide reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->