### PR TITLE
fix: stop export-ignore from stripping the CspTest command (2.0.1)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,8 +5,6 @@
 /tests              export-ignore
 /.idea export-ignore
 /src/**/Tests       export-ignore
-/src/**/*Test.php   export-ignore
-/src/**/Test.php    export-ignore
 /phpunit.xml   export-ignore
 /.gitlab-ci.yml export-ignore
 /.gitattributes export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-05-21
+
+### Fixed
+
+- Restore the `csp:test` command (`CspTest`) to the distributed package. An over-broad `export-ignore` rule (`/src/**/*Test.php`) stripped it from the release tarball, so `SecurityServiceProvider` registered a class that wasn't shipped — causing `Target class [ArtisanPackUI\Security\Console\Commands\CspTest] does not exist` during package discovery for every consumer.
+
 ## [2.0.0] - 2026-05-18
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Core Laravel security toolkit — input sanitization, output escaping, KSES filtering, security headers, XSS protection, basic rate limiting, and Content Security Policy. Authentication / 2FA / RBAC / file uploads / analytics / compliance live in sibling packages.",
   "type": "library",
   "license": "MIT",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "laravel",
     "security",


### PR DESCRIPTION
## Summary
- Removes the over-broad `.gitattributes` rules `/src/**/*Test.php` and `/src/**/Test.php`.
- Bumps to `2.0.1` + CHANGELOG entry.

### Why
`/src/**/*Test.php export-ignore` was meant to strip PHPUnit tests, but it also matched the legitimate **`CspTest`** command (`csp:test`). The published 2.0.0 dist tarball therefore omitted `src/Console/Commands/CspTest.php`, while `SecurityServiceProvider` still registers `CspTest::class`. Any consumer hit:

```
Target class [ArtisanPackUI\Security\Console\Commands\CspTest] does not exist.
```

…on every `composer`/`artisan` invocation (fails `package:discover`). `CspTest.php` is the only file under `src/` those globs matched; real tests live in `/tests` and `/src/**/Tests` (still ignored).

### Verification
`git archive HEAD | tar t` now includes `src/Console/Commands/CspTest.php` and still excludes `tests/`.

## Test plan
- [ ] CI green (test suite already passing locally: 255 passed)
- [ ] After tagging `v2.0.1`, install in a consumer app and confirm `package:discover` succeeds + `php artisan csp:test` exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Restored the `csp:test` command to the distributed package. This command was previously unavailable due to overly broad export configuration rules, causing package discovery failures. The issue has been resolved in version 2.0.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/security/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->