### PR TITLE
Release v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Laravel 13 support. Widened the `illuminate/support` constraint to `^10.0|^11.0|^12.0|^13.0`. Existing Laravel 10/11/12 users are unaffected; Laravel 13 is only selectable on PHP 8.3+ per its own framework constraint.
+
 ## [2.0.1] - 2026-05-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-06-09
+
 ### Added
 
 - Laravel 13 support. Widened the `illuminate/support` constraint to `^10.0|^11.0|^12.0|^13.0`. Existing Laravel 10/11/12 users are unaffected; Laravel 13 is only selectable on PHP 8.3+ per its own framework constraint.
+
+### Changed
+
+- Widened `orchestra/testbench` dev requirement to `^10.2|^11.0` so package tests can install against Laravel 13.
+- Swept the package through Laravel Pint to bring it back in line with the configured code style (no behavioral changes).
 
 ## [2.0.1] - 2026-05-21
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Route::middleware('api.rate_limit:api')->group(function () {
 ## Requirements
 
 - PHP 8.2+
-- Laravel 10 / 11 / 12
+- Laravel 10 / 11 / 12 / 13 (Laravel 13 requires PHP 8.3+)
 
 ## Sibling packages
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "friendsofphp/php-cs-fixer": "^3.75",
     "laravel/pint": "^1.26",
     "livewire/livewire": "^3.6|^4.0",
-    "orchestra/testbench": "^10.2",
+    "orchestra/testbench": "^10.2|^11.0",
     "pestphp/pest": "^3.8",
     "pestphp/pest-plugin-laravel": "^3.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Core Laravel security toolkit — input sanitization, output escaping, KSES filtering, security headers, XSS protection, basic rate limiting, and Content Security Policy. Authentication / 2FA / RBAC / file uploads / analytics / compliance live in sibling packages.",
   "type": "library",
   "license": "MIT",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "laravel",
     "security",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "illuminate/support": "^10.0|^11.0|^12.0",
+    "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
     "laminas/laminas-escaper": "^2.16",
     "artisanpack-ui/core": "^1.0",
     "laravel/sanctum": "^4.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d051bad5ffcd98c3d1041de86a8711a6",
+    "content-hash": "dd8c324af6aa773653b825027ff9cc39",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "608f2937899770f71357c63e78f09ad3",
+    "content-hash": "d051bad5ffcd98c3d1041de86a8711a6",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/composer.lock
+++ b/composer.lock
@@ -4,38 +4,46 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d03bdc86eef08120daf135222a6a1bbf",
+    "content-hash": "608f2937899770f71357c63e78f09ad3",
     "packages": [
         {
             "name": "artisanpack-ui/core",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/core.git",
-                "reference": "16e91edb542948ee335c618a17fdc60f8593d671"
+                "reference": "bb7055c4b250612d987398f990b5537fbc28865b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/core/zipball/16e91edb542948ee335c618a17fdc60f8593d671",
-                "reference": "16e91edb542948ee335c618a17fdc60f8593d671",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/core/zipball/bb7055c4b250612d987398f990b5537fbc28865b",
+                "reference": "bb7055c4b250612d987398f990b5537fbc28865b",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": "^11.0|^12.0",
+                "composer/semver": "^3.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
                 "laravel/prompts": "^0.3",
                 "php": "^8.2"
             },
             "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
                 "laravel/pint": "^1.27",
-                "orchestra/testbench": "^10.2",
-                "pestphp/pest": "^3.8",
-                "pestphp/pest-plugin-laravel": "^3.1"
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.1|^4.0",
+                "squizlabs/php_codesniffer": "3.11.3"
             },
             "type": "library",
             "extra": {
                 "laravel": {
                     "aliases": {
-                        "Core": "ArtisanPackUI\\Core\\Facades\\Core"
+                        "Core": "ArtisanPackUI\\Core\\Facades\\Core",
+                        "ArtisanPackLog": "ArtisanPackUI\\Core\\Facades\\ArtisanPackLog",
+                        "ArtisanPackConfig": "ArtisanPackUI\\Core\\Facades\\ArtisanPackConfig"
                     },
                     "providers": [
                         "ArtisanPackUI\\Core\\CoreServiceProvider"
@@ -63,9 +71,9 @@
             "description": "Supplies the core functionality for ArtisanPack UI that needs to be shared across all packages.",
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/core/issues",
-                "source": "https://github.com/ArtisanPack-UI/core/tree/v1.1.0"
+                "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
-            "time": "2026-01-10T02:20:40+00:00"
+            "time": "2026-05-24T02:53:50+00:00"
         },
         {
             "name": "brick/math",
@@ -195,6 +203,83 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -704,25 +789,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.11",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -731,8 +817,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.5",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -810,7 +897,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.11.1"
             },
             "funding": [
                 {
@@ -826,28 +913,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-07T22:54:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -893,7 +981,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -909,27 +997,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -937,9 +1027,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1010,7 +1100,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
             },
             "funding": [
                 {
@@ -1026,20 +1116,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-06-02T12:30:48+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.5",
+            "version": "v1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/eef7f87bab6f204eba3c39224d8075c70c637946",
+                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946",
                 "shasum": ""
             },
             "require": {
@@ -1048,7 +1138,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "uri-template/tests": "1.0.0"
             },
             "type": "library",
@@ -1096,7 +1186,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.6"
             },
             "funding": [
                 {
@@ -1112,7 +1202,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:27:06+00:00"
+            "time": "2026-05-23T22:00:21+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -1177,16 +1267,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.58.0",
+            "version": "v12.62.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "6172ae1f44ba5d89e111057ee4a4e7c27f5a610d"
+                "reference": "f7e61eb1e0e06a38996802b769bce9127aec227c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/6172ae1f44ba5d89e111057ee4a4e7c27f5a610d",
-                "reference": "6172ae1f44ba5d89e111057ee4a4e7c27f5a610d",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/f7e61eb1e0e06a38996802b769bce9127aec227c",
+                "reference": "f7e61eb1e0e06a38996802b769bce9127aec227c",
                 "shasum": ""
             },
             "require": {
@@ -1395,20 +1485,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-04-26T16:42:04+00:00"
+            "time": "2026-06-09T13:50:13+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.17",
+            "version": "v0.3.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818"
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/6a82ac19a28b916ae0885828795dbd4c59d9a818",
-                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/a19af51bb144bf87f08397921fa619f85c7d4e72",
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72",
                 "shasum": ""
             },
             "require": {
@@ -1452,9 +1542,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.17"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.18"
             },
-            "time": "2026-04-20T16:07:33+00:00"
+            "time": "2026-05-19T00:47:18+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -1771,16 +1861,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.33.0",
+            "version": "3.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "570b8871e0ce693764434b29154c54b434905350"
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/570b8871e0ce693764434b29154c54b434905350",
-                "reference": "570b8871e0ce693764434b29154c54b434905350",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
                 "shasum": ""
             },
             "require": {
@@ -1848,9 +1938,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.33.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.34.0"
             },
-            "time": "2026-03-25T07:59:30+00:00"
+            "time": "2026-05-14T10:28:08+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -2416,16 +2506,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.3",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
@@ -2501,9 +2591,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.3"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2026-02-13T03:05:33+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -3357,16 +3447,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.9",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d7d2b64a45a89d607865927b176fa51c33ddbb58"
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d7d2b64a45a89d607865927b176fa51c33ddbb58",
-                "reference": "d7d2b64a45a89d607865927b176fa51c33ddbb58",
+                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
                 "shasum": ""
             },
             "require": {
@@ -3431,7 +3521,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.9"
+                "source": "https://github.com/symfony/console/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -3451,7 +3541,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-22T15:21:55+00:00"
+            "time": "2026-05-24T08:56:14+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -3910,16 +4000,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab"
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9381209597ec66c25be154cbf2289076e64d1eab",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bc354f47c62301e990b7874fa662326368508e2c",
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c",
                 "shasum": ""
             },
             "require": {
@@ -3968,7 +4058,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.8"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -3988,20 +4078,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.10",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "23486f59234c6fd6e8f1bec97124f3829d686627"
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/23486f59234c6fd6e8f1bec97124f3829d686627",
-                "reference": "23486f59234c6fd6e8f1bec97124f3829d686627",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9df847980c436451f4f51d1284491bb4356dd989",
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989",
                 "shasum": ""
             },
             "require": {
@@ -4087,7 +4177,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.10"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4107,20 +4197,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-06T12:07:34+00:00"
+            "time": "2026-05-27T08:31:43+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.8",
+            "version": "v7.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62"
+                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/f6ea532250b476bfc1b56699b388a1bdbf168f62",
-                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/5cefb712a25f320579615ba9e1942abaeade7dff",
+                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff",
                 "shasum": ""
             },
             "require": {
@@ -4171,7 +4261,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.8"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.12"
             },
             "funding": [
                 {
@@ -4191,20 +4281,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-20T07:20:23+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.9",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "2d550c4758ba4c47519a6667c36553d535705b0c"
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/2d550c4758ba4c47519a6667c36553d535705b0c",
-                "reference": "2d550c4758ba4c47519a6667c36553d535705b0c",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
                 "shasum": ""
             },
             "require": {
@@ -4260,7 +4350,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.9"
+                "source": "https://github.com/symfony/mime/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4280,7 +4370,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T13:21:53+00:00"
+            "time": "2026-05-23T16:22:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4367,16 +4457,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -4425,7 +4515,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4445,20 +4535,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:13:48+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -4512,7 +4602,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4532,20 +4622,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -4597,7 +4687,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -4617,20 +4707,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -4682,7 +4772,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -4702,7 +4792,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -4790,16 +4880,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.37.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -4846,7 +4936,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -4866,20 +4956,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -4926,7 +5016,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4946,20 +5036,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T18:47:49+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee"
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/fcfa4973a9917cef23f2e38774da74a2b7d115ee",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
                 "shasum": ""
             },
             "require": {
@@ -5006,7 +5096,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5026,7 +5116,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:10:57+00:00"
+            "time": "2026-05-26T02:25:22+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
@@ -5113,16 +5203,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
@@ -5154,7 +5244,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5174,20 +5264,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.9",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f"
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/287771d8bc86eacb30678dd10eda6c64a859951f",
-                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
                 "shasum": ""
             },
             "require": {
@@ -5239,7 +5329,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.9"
+                "source": "https://github.com/symfony/routing/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5259,7 +5349,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-22T15:21:55+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -5350,16 +5440,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "114ac57257d75df748eda23dd003878080b8e688"
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/114ac57257d75df748eda23dd003878080b8e688",
-                "reference": "114ac57257d75df748eda23dd003878080b8e688",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
                 "shasum": ""
             },
             "require": {
@@ -5417,7 +5507,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.8"
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5437,7 +5527,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "symfony/translation",
@@ -6003,16 +6093,16 @@
     "packages-dev": [
         {
             "name": "artisanpack-ui/code-style",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/code-style.git",
-                "reference": "c515b88b18ba99b758f1a22279701bbb7c79cf1b"
+                "reference": "d036dea1e09f5262d244f743b0e7417c77dcce25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/code-style/zipball/c515b88b18ba99b758f1a22279701bbb7c79cf1b",
-                "reference": "c515b88b18ba99b758f1a22279701bbb7c79cf1b",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/code-style/zipball/d036dea1e09f5262d244f743b0e7417c77dcce25",
+                "reference": "d036dea1e09f5262d244f743b0e7417c77dcce25",
                 "shasum": ""
             },
             "require": {
@@ -6051,26 +6141,26 @@
             "description": "A custom PHP code style standard based on PHPStorm settings. This package provides custom sniffs for PHP_CodeSniffer that enforce consistent code style across your PHP projects.",
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/code-style/issues",
-                "source": "https://github.com/ArtisanPack-UI/code-style/tree/v1.1.0"
+                "source": "https://github.com/ArtisanPack-UI/code-style/tree/v1.1.1"
             },
-            "time": "2025-11-22T21:01:09+00:00"
+            "time": "2026-06-05T17:37:21+00:00"
         },
         {
             "name": "artisanpack-ui/code-style-pint",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/code-style-pint.git",
-                "reference": "31997861d7564c044a7c7b93df792cafcb93dab6"
+                "reference": "5d1f125a920082e8bfa978d4f6cedde07d0a7e53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/code-style-pint/zipball/31997861d7564c044a7c7b93df792cafcb93dab6",
-                "reference": "31997861d7564c044a7c7b93df792cafcb93dab6",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/code-style-pint/zipball/5d1f125a920082e8bfa978d4f6cedde07d0a7e53",
+                "reference": "5d1f125a920082e8bfa978d4f6cedde07d0a7e53",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
                 "php": "^8.2"
             },
             "require-dev": {
@@ -6113,9 +6203,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/code-style-pint/issues",
-                "source": "https://github.com/ArtisanPack-UI/code-style-pint/tree/v1.1.0"
+                "source": "https://github.com/ArtisanPack-UI/code-style-pint/tree/v1.1.1"
             },
-            "time": "2025-11-23T21:13:56+00:00"
+            "time": "2026-06-09T00:58:49+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -6352,83 +6442,6 @@
                 }
             ],
             "time": "2024-11-12T16:29:46+00:00"
-        },
-        {
-            "name": "composer/semver",
-            "version": "3.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.11",
-                "symfony/phpunit-bridge": "^3 || ^7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "support": {
-                "irc": "ircs://irc.libera.chat:6697/composer",
-                "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.4"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -6953,23 +6966,23 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.1",
+            "version": "v3.95.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065"
+                "reference": "7f86d8763063f5d2e2e2d0e1e45bb2f15895361d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a9727678fbd12997f1d9de8f4a37824ed9df1065",
-                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/7f86d8763063f5d2e2e2d0e1e45bb2f15895361d",
+                "reference": "7f86d8763063f5d2e2e2d0e1e45bb2f15895361d",
                 "shasum": ""
             },
             "require": {
                 "clue/ndjson-react": "^1.3",
                 "composer/semver": "^3.4",
                 "composer/xdebug-handler": "^3.0.5",
-                "ergebnis/agent-detector": "^1.1.1",
+                "ergebnis/agent-detector": "^1.2",
                 "ext-filter": "*",
                 "ext-hash": "*",
                 "ext-json": "*",
@@ -6980,22 +6993,22 @@
                 "react/event-loop": "^1.5",
                 "react/socket": "^1.16",
                 "react/stream": "^1.4",
-                "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0 || ^8.0",
+                "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0 || ^8.0 || ^9.0",
                 "symfony/console": "^5.4.47 || ^6.4.24 || ^7.0 || ^8.0",
                 "symfony/event-dispatcher": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
                 "symfony/filesystem": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
                 "symfony/finder": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
                 "symfony/options-resolver": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
-                "symfony/polyfill-mbstring": "^1.33",
-                "symfony/polyfill-php80": "^1.33",
-                "symfony/polyfill-php81": "^1.33",
-                "symfony/polyfill-php84": "^1.33",
+                "symfony/polyfill-mbstring": "^1.37",
+                "symfony/polyfill-php80": "^1.37",
+                "symfony/polyfill-php81": "^1.37",
+                "symfony/polyfill-php84": "^1.37",
                 "symfony/process": "^5.4.47 || ^6.4.24 || ^7.2 || ^8.0",
                 "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "facile-it/paraunit": "^1.3.1 || ^2.8.0",
-                "infection/infection": "^0.32.6",
+                "facile-it/paraunit": "^1.3.1 || ^2.11.0",
+                "infection/infection": "^0.32.7",
                 "justinrainbow/json-schema": "^6.8.0",
                 "keradus/cli-executor": "^2.3",
                 "mikey179/vfsstream": "^1.6.12",
@@ -7003,9 +7016,9 @@
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
                 "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.55",
-                "symfony/polyfill-php85": "^1.33",
+                "symfony/polyfill-php85": "^1.37",
                 "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.8",
-                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.8"
+                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.11"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -7046,7 +7059,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.5"
             },
             "funding": [
                 {
@@ -7054,7 +7067,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-12T17:00:09+00:00"
+            "time": "2026-06-09T14:55:16+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -7169,16 +7182,16 @@
         },
         {
             "name": "laravel/pail",
-            "version": "v1.2.6",
+            "version": "v1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pail.git",
-                "reference": "aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf"
+                "reference": "2f7d27dada8effc48b8c424445a69cca7007daaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pail/zipball/aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf",
-                "reference": "aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf",
+                "url": "https://api.github.com/repos/laravel/pail/zipball/2f7d27dada8effc48b8c424445a69cca7007daaa",
+                "reference": "2f7d27dada8effc48b8c424445a69cca7007daaa",
                 "shasum": ""
             },
             "require": {
@@ -7245,7 +7258,7 @@
                 "issues": "https://github.com/laravel/pail/issues",
                 "source": "https://github.com/laravel/pail"
             },
-            "time": "2026-02-09T13:44:54+00:00"
+            "time": "2026-05-20T22:24:57+00:00"
         },
         {
             "name": "laravel/pint",
@@ -7383,16 +7396,16 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v4.3.0",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "19ebb1ee4d057debceccf70ff01950e6a6114edc"
+                "reference": "6a9dd03f45a4b200abfd0ff644745b23fa7baaaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/19ebb1ee4d057debceccf70ff01950e6a6114edc",
-                "reference": "19ebb1ee4d057debceccf70ff01950e6a6114edc",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/6a9dd03f45a4b200abfd0ff644745b23fa7baaaa",
+                "reference": "6a9dd03f45a4b200abfd0ff644745b23fa7baaaa",
                 "shasum": ""
             },
             "require": {
@@ -7447,7 +7460,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v4.3.0"
+                "source": "https://github.com/livewire/livewire/tree/v4.3.1"
             },
             "funding": [
                 {
@@ -7455,7 +7468,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-01T00:46:07+00:00"
+            "time": "2026-06-02T08:58:52+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -9370,16 +9383,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.22",
+            "version": "v0.12.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "3be75d5b9244936dd4ac62ade2bfb004d13acf0f"
+                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/3be75d5b9244936dd4ac62ade2bfb004d13acf0f",
-                "reference": "3be75d5b9244936dd4ac62ade2bfb004d13acf0f",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4dcc0f08047d52bbde475eda481146fd8e27e1a4",
+                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4",
                 "shasum": ""
             },
             "require": {
@@ -9443,9 +9456,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.22"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.23"
             },
-            "time": "2026-03-22T23:03:24+00:00"
+            "time": "2026-05-23T13:41:31+00:00"
         },
         {
             "name": "react/cache",
@@ -11092,16 +11105,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.9",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "dcd8f96bcdc0f128ec406c765cc066c6035d1be3"
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/dcd8f96bcdc0f128ec406c765cc066c6035d1be3",
-                "reference": "dcd8f96bcdc0f128ec406c765cc066c6035d1be3",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
                 "shasum": ""
             },
             "require": {
@@ -11138,7 +11151,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.9"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -11158,7 +11171,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:18:21+00:00"
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -11233,16 +11246,16 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
                 "shasum": ""
             },
             "require": {
@@ -11289,7 +11302,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -11309,7 +11322,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -11379,16 +11392,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.10",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "c660d6538545a3e8e65a5621ee3d7a6d352892c7"
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/c660d6538545a3e8e65a5621ee3d7a6d352892c7",
-                "reference": "c660d6538545a3e8e65a5621ee3d7a6d352892c7",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
                 "shasum": ""
             },
             "require": {
@@ -11431,7 +11444,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.10"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -11451,7 +11464,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-05T08:01:55+00:00"
+            "time": "2026-05-25T06:06:12+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
@@ -11564,16 +11577,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4"
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
-                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155",
                 "shasum": ""
             },
             "require": {
@@ -11589,7 +11602,11 @@
             },
             "type": "library",
             "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
                 "branch-alias": {
+                    "dev-master": "2.0-dev",
                     "dev-feature/2-0": "2.0-dev"
                 }
             },
@@ -11620,9 +11637,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.3.0"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.0"
             },
-            "time": "2026-04-11T10:33:05+00:00"
+            "time": "2026-05-20T13:07:01+00:00"
         }
     ],
     "aliases": [],

--- a/config/security.php
+++ b/config/security.php
@@ -126,7 +126,7 @@ return [
              * Default rate limit for authenticated API requests.
              */
             'authenticated' => [
-                'max_attempts'  => env('API_RATE_LIMIT_AUTHENTICATED', 60),
+                'max_attempts' => env('API_RATE_LIMIT_AUTHENTICATED', 60),
                 'decay_minutes' => 1,
             ],
 
@@ -134,7 +134,7 @@ return [
              * Rate limit for unauthenticated/guest API requests.
              */
             'guest' => [
-                'max_attempts'  => env('API_RATE_LIMIT_GUEST', 30),
+                'max_attempts' => env('API_RATE_LIMIT_GUEST', 30),
                 'decay_minutes' => 1,
             ],
         ],

--- a/docs/advanced/video-tutorials.md
+++ b/docs/advanced/video-tutorials.md
@@ -25,7 +25,7 @@ Learn how to install and configure the ArtisanPack Security package in a fresh L
 A Laravel application with the security package installed and basic configuration complete.
 
 **Prerequisites**:
-- Laravel 10.x or 11.x application
+- Laravel 10.x, 11.x, 12.x, or 13.x application
 - Composer installed
 - Basic Laravel knowledge
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,7 +10,7 @@ Common questions about the ArtisanPack Security package.
 
 ### What Laravel versions are supported?
 
-The package supports Laravel 10.x and 11.x. PHP 8.1 or higher is required.
+The package supports Laravel 10.x, 11.x, 12.x, and 13.x. PHP 8.2 or higher is required (Laravel 13 requires PHP 8.3+).
 
 ### Can I use this package with Jetstream/Breeze?
 

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -10,7 +10,7 @@ title: Requirements
 
 ## Laravel
 
-- Laravel 10 / 11 / 12
+- Laravel 10 / 11 / 12 / 13 (Laravel 13 requires PHP 8.3+)
 
 ## Runtime dependencies
 

--- a/src/Console/Commands/CheckSecurityConfiguration.php
+++ b/src/Console/Commands/CheckSecurityConfiguration.php
@@ -49,18 +49,18 @@ class CheckSecurityConfiguration extends Command
      * @var array<string, string>
      */
     protected array $categories = [
-        'env'        => 'Environment Configuration',
-        'session'    => 'Session Security',
-        'database'   => 'Database Security',
-        'cache'      => 'Cache Configuration',
-        'mail'       => 'Mail Security',
+        'env' => 'Environment Configuration',
+        'session' => 'Session Security',
+        'database' => 'Database Security',
+        'cache' => 'Cache Configuration',
+        'mail' => 'Mail Security',
         'filesystem' => 'Filesystem Security',
-        'security'   => 'General Security',
-        'api'        => 'API Security',
-        'rbac'       => 'RBAC Configuration',
-        'csp'        => 'Content Security Policy',
-        'password'   => 'Password Policy',
-        'upload'     => 'File Upload Security',
+        'security' => 'General Security',
+        'api' => 'API Security',
+        'rbac' => 'RBAC Configuration',
+        'csp' => 'Content Security Policy',
+        'password' => 'Password Policy',
+        'upload' => 'File Upload Security',
     ];
 
     public function __construct(EnvironmentValidationService $validator)
@@ -75,10 +75,10 @@ class CheckSecurityConfiguration extends Command
     public function handle(): int
     {
         $environment = App::environment();
-        $category    = $this->option('category');
-        $isJson      = $this->option('json');
-        $isStrict    = $this->option('strict');
-        $showPassed  = $this->option('show-passed');
+        $category = $this->option('category');
+        $isJson = $this->option('json');
+        $isStrict = $this->option('strict');
+        $showPassed = $this->option('show-passed');
 
         // Get ignored checks
         $ignoredChecks = [];
@@ -98,12 +98,12 @@ class CheckSecurityConfiguration extends Command
         $additionalResults = $this->runAdditionalChecks($category);
 
         // Merge results
-        $errors   = array_merge($results['errors'] ?? [], $additionalResults['errors'] ?? []);
+        $errors = array_merge($results['errors'] ?? [], $additionalResults['errors'] ?? []);
         $warnings = array_merge($results['warnings'] ?? [], $additionalResults['warnings'] ?? []);
-        $passed   = $additionalResults['passed'] ?? [];
+        $passed = $additionalResults['passed'] ?? [];
 
         // Apply ignored checks
-        $errors   = $this->filterIgnored($errors, $ignoredChecks);
+        $errors = $this->filterIgnored($errors, $ignoredChecks);
         $warnings = $this->filterIgnored($warnings, $ignoredChecks);
 
         // Output results
@@ -121,26 +121,26 @@ class CheckSecurityConfiguration extends Command
      */
     protected function runAdditionalChecks(?string $category): array
     {
-        $errors   = [];
+        $errors = [];
         $warnings = [];
-        $passed   = [];
+        $passed = [];
 
         $categoriesToCheck = $category ? [$category] : array_keys($this->categories);
 
         foreach ($categoriesToCheck as $cat) {
             $method = 'check'.ucfirst($cat);
             if (method_exists($this, $method)) {
-                $result   = $this->$method();
-                $errors   = array_merge($errors, $result['errors'] ?? []);
+                $result = $this->$method();
+                $errors = array_merge($errors, $result['errors'] ?? []);
                 $warnings = array_merge($warnings, $result['warnings'] ?? []);
-                $passed   = array_merge($passed, $result['passed'] ?? []);
+                $passed = array_merge($passed, $result['passed'] ?? []);
             }
         }
 
         return [
-            'errors'   => $errors,
+            'errors' => $errors,
             'warnings' => $warnings,
-            'passed'   => $passed,
+            'passed' => $passed,
         ];
     }
 
@@ -151,9 +151,9 @@ class CheckSecurityConfiguration extends Command
      */
     protected function checkApi(): array
     {
-        $errors   = [];
+        $errors = [];
         $warnings = [];
-        $passed   = [];
+        $passed = [];
 
         $apiConfig = config('artisanpack.security.api', []);
 
@@ -165,7 +165,7 @@ class CheckSecurityConfiguration extends Command
 
         // Token expiration
         $expiration = $apiConfig['tokens']['expiration'] ?? null;
-        if (null === $expiration) {
+        if ($expiration === null) {
             $warnings[] = '[API-002] API tokens do not expire by default';
         } elseif ($expiration > 60 * 24 * 30) { // 30 days
             $warnings[] = '[API-003] API token expiration is very long (> 30 days)';
@@ -191,9 +191,9 @@ class CheckSecurityConfiguration extends Command
      */
     protected function checkRbac(): array
     {
-        $errors   = [];
+        $errors = [];
         $warnings = [];
-        $passed   = [];
+        $passed = [];
 
         $rbacConfig = config('artisanpack.security.rbac', []);
 
@@ -213,12 +213,12 @@ class CheckSecurityConfiguration extends Command
      */
     protected function checkCsp(): array
     {
-        $errors   = [];
+        $errors = [];
         $warnings = [];
-        $passed   = [];
+        $passed = [];
 
         $cspConfig = config('artisanpack.security.csp', []);
-        $headers   = config('artisanpack.security.security-headers', []);
+        $headers = config('artisanpack.security.security-headers', []);
 
         // Check if CSP is configured
         $cspHeader = $headers['Content-Security-Policy'] ?? '';
@@ -264,9 +264,9 @@ class CheckSecurityConfiguration extends Command
      */
     protected function checkPassword(): array
     {
-        $errors   = [];
+        $errors = [];
         $warnings = [];
-        $passed   = [];
+        $passed = [];
 
         $passwordConfig = config('artisanpack.security.passwordSecurity', []);
 
@@ -300,9 +300,9 @@ class CheckSecurityConfiguration extends Command
      */
     protected function checkUpload(): array
     {
-        $errors   = [];
+        $errors = [];
         $warnings = [];
-        $passed   = [];
+        $passed = [];
 
         $uploadConfig = config('artisanpack.security.fileUpload', []);
 
@@ -314,7 +314,7 @@ class CheckSecurityConfiguration extends Command
 
         // Malware scanning
         $scannerDriver = $uploadConfig['malware']['driver'] ?? 'null';
-        if ('null' === $scannerDriver) {
+        if ($scannerDriver === 'null') {
             $warnings[] = '[UPLOAD-002] Malware scanning is disabled (null driver)';
         } else {
             $passed[] = "[UPLOAD-002] Malware scanning is enabled ({$scannerDriver})";
@@ -329,7 +329,7 @@ class CheckSecurityConfiguration extends Command
 
         // Dangerous extensions blocked
         $dangerousExts = ['php', 'phtml', 'php3', 'php4', 'php5', 'exe', 'sh', 'bat'];
-        $blockedExts   = $uploadConfig['validation']['blockedExtensions'] ?? [];
+        $blockedExts = $uploadConfig['validation']['blockedExtensions'] ?? [];
         $missingBlocks = array_diff($dangerousExts, $blockedExts);
         if (! empty($missingBlocks)) {
             $warnings[] = '[UPLOAD-004] Some dangerous extensions not blocked: '.implode(', ', $missingBlocks);
@@ -347,17 +347,17 @@ class CheckSecurityConfiguration extends Command
      */
     protected function checkSession(): array
     {
-        $errors   = [];
+        $errors = [];
         $warnings = [];
-        $passed   = [];
+        $passed = [];
 
-        $sessionDriver   = config('session.driver');
-        $sessionSecure   = config('session.secure');
+        $sessionDriver = config('session.driver');
+        $sessionSecure = config('session.secure');
         $sessionHttpOnly = config('session.http_only');
         $sessionSameSite = config('session.same_site');
 
         // Session driver
-        if ('file' === $sessionDriver) {
+        if ($sessionDriver === 'file') {
             $warnings[] = '[SESSION-001] Using file session driver (consider database or redis for production)';
         } else {
             $passed[] = "[SESSION-001] Using {$sessionDriver} session driver";
@@ -378,7 +378,7 @@ class CheckSecurityConfiguration extends Command
         }
 
         // SameSite
-        if (empty($sessionSameSite) || 'none' === $sessionSameSite) {
+        if (empty($sessionSameSite) || $sessionSameSite === 'none') {
             $warnings[] = '[SESSION-004] Session SameSite attribute is not set or is "none"';
         } else {
             $passed[] = "[SESSION-004] Session SameSite is '{$sessionSameSite}'";
@@ -394,9 +394,9 @@ class CheckSecurityConfiguration extends Command
      */
     protected function checkSecurity(): array
     {
-        $errors   = [];
+        $errors = [];
         $warnings = [];
-        $passed   = [];
+        $passed = [];
 
         $headers = config('artisanpack.security.security-headers', []);
 
@@ -441,7 +441,6 @@ class CheckSecurityConfiguration extends Command
      *
      * @param  array<string>  $items
      * @param  array<string>  $ignored
-     *
      * @return array<string>
      */
     protected function filterIgnored(array $items, array $ignored): array
@@ -478,22 +477,22 @@ class CheckSecurityConfiguration extends Command
         }
 
         $output = [
-            'status'      => $status,
+            'status' => $status,
             'environment' => App::environment(),
-            'timestamp'   => now()->toIso8601String(),
-            'summary'     => [
-                'errors'   => count($errors),
+            'timestamp' => now()->toIso8601String(),
+            'summary' => [
+                'errors' => count($errors),
                 'warnings' => count($warnings),
-                'passed'   => count($passed),
+                'passed' => count($passed),
             ],
-            'errors'   => $errors,
+            'errors' => $errors,
             'warnings' => $warnings,
-            'passed'   => $passed,
+            'passed' => $passed,
         ];
 
         $this->line(json_encode($output, JSON_PRETTY_PRINT));
 
-        return 'failed' === $status ? self::FAILURE : self::SUCCESS;
+        return $status === 'failed' ? self::FAILURE : self::SUCCESS;
     }
 
     /**

--- a/src/Console/Commands/ClearRateLimits.php
+++ b/src/Console/Commands/ClearRateLimits.php
@@ -24,7 +24,7 @@ class ClearRateLimits extends Command
 
     public function handle(): int
     {
-        $ip   = $this->option('ip');
+        $ip = $this->option('ip');
         $user = $this->option('user');
 
         if (! $ip && ! $user) {

--- a/src/Console/Commands/CspPrune.php
+++ b/src/Console/Commands/CspPrune.php
@@ -52,7 +52,7 @@ class CspPrune extends Command
             ->where('last_seen_at', '<', now()->subDays($days))
             ->count();
 
-        if (0 === $count) {
+        if ($count === 0) {
             $this->info('No violation reports to prune.');
 
             return self::SUCCESS;

--- a/src/Console/Commands/CspStats.php
+++ b/src/Console/Commands/CspStats.php
@@ -57,7 +57,7 @@ class CspStats extends Command
         $this->newLine();
 
         // Summary statistics
-        $totalCount  = CspViolationReport::getTotalCount($hours);
+        $totalCount = CspViolationReport::getTotalCount($hours);
         $uniqueCount = CspViolationReport::getUniqueCount($hours);
 
         $this->line("<fg=cyan>Total Occurrences:</> {$totalCount}");
@@ -188,12 +188,12 @@ class CspStats extends Command
     protected function formatDirective(string $directive): string
     {
         return match (true) {
-            str_starts_with($directive, 'script-src')  => "<fg=red>{$directive}</>",
-            str_starts_with($directive, 'style-src')   => "<fg=yellow>{$directive}</>",
-            str_starts_with($directive, 'img-src')     => "<fg=blue>{$directive}</>",
+            str_starts_with($directive, 'script-src') => "<fg=red>{$directive}</>",
+            str_starts_with($directive, 'style-src') => "<fg=yellow>{$directive}</>",
+            str_starts_with($directive, 'img-src') => "<fg=blue>{$directive}</>",
             str_starts_with($directive, 'connect-src') => "<fg=magenta>{$directive}</>",
-            str_starts_with($directive, 'font-src')    => "<fg=cyan>{$directive}</>",
-            default                                    => $directive,
+            str_starts_with($directive, 'font-src') => "<fg=cyan>{$directive}</>",
+            default => $directive,
         };
     }
 }

--- a/src/Console/Commands/CspTest.php
+++ b/src/Console/Commands/CspTest.php
@@ -159,7 +159,7 @@ class CspTest extends Command
     protected function parseDirectives(string $policy): array
     {
         $directives = [];
-        $parts      = explode(';', $policy);
+        $parts = explode(';', $policy);
 
         foreach ($parts as $part) {
             $part = trim($part);
@@ -167,8 +167,8 @@ class CspTest extends Command
                 continue;
             }
 
-            $tokens                 = preg_split('/\s+/', $part);
-            $directive              = array_shift($tokens);
+            $tokens = preg_split('/\s+/', $part);
+            $directive = array_shift($tokens);
             $directives[$directive] = $tokens;
         }
 
@@ -202,7 +202,7 @@ class CspTest extends Command
         }
 
         // Check for strict-dynamic (good for scripts)
-        if ('script-src' === $directive && in_array("'strict-dynamic'", $values, true)) {
+        if ($directive === 'script-src' && in_array("'strict-dynamic'", $values, true)) {
             return '<fg=green>Strict Dynamic</>';
         }
 
@@ -225,7 +225,7 @@ class CspTest extends Command
         }
 
         // Check for self only
-        if (1 === count($values) && "'self'" === $values[0]) {
+        if (count($values) === 1 && $values[0] === "'self'") {
             return '<fg=green>Self only</>';
         }
 
@@ -257,7 +257,7 @@ class CspTest extends Command
         $this->info('Security Recommendations:');
 
         $recommendations = [];
-        $directives      = $this->parseDirectives($policy);
+        $directives = $this->parseDirectives($policy);
 
         // Check for missing important directives
         $important = ['default-src', 'script-src', 'style-src', 'object-src', 'base-uri', 'frame-ancestors'];
@@ -280,7 +280,7 @@ class CspTest extends Command
         // Check for unsafe inline without nonce
         if (isset($directives['script-src'])) {
             $scriptSrc = $directives['script-src'];
-            $hasNonce  = false;
+            $hasNonce = false;
             foreach ($scriptSrc as $value) {
                 if (str_starts_with($value, "'nonce-")) {
                     $hasNonce = true;

--- a/src/Console/Commands/GenerateCspPolicy.php
+++ b/src/Console/Commands/GenerateCspPolicy.php
@@ -57,7 +57,7 @@ class GenerateCspPolicy extends Command
         $this->info('CSP Policy Generator');
         $this->newLine();
 
-        $preset           = $this->option('preset');
+        $preset = $this->option('preset');
         $availablePresets = array_keys($csp->getPresets());
 
         if (! in_array($preset, $availablePresets, true)) {
@@ -105,7 +105,7 @@ class GenerateCspPolicy extends Command
         // Output to file or display
         if ($outputPath = $this->option('output')) {
             $result = File::put($outputPath, $output);
-            if (false === $result) {
+            if ($result === false) {
                 $this->error("Failed to write policy to: {$outputPath}");
 
                 return self::FAILURE;
@@ -246,7 +246,7 @@ class GenerateCspPolicy extends Command
 
         if ($outputPath = $this->ask('Save to file? (leave empty to display)')) {
             $result = File::put($outputPath, $output);
-            if (false === $result) {
+            if ($result === false) {
                 $this->error("Failed to save policy to: {$outputPath}");
 
                 return self::FAILURE;
@@ -304,11 +304,11 @@ class GenerateCspPolicy extends Command
      */
     protected function applyImgChoice(CspPolicyBuilder $builder, string $choice): void
     {
-        if ("'self'" === $choice) {
+        if ($choice === "'self'") {
             $builder->imgSrc("'self'");
-        } elseif ("'self' data:" === $choice) {
+        } elseif ($choice === "'self' data:") {
             $builder->imgSrc("'self'", 'data:');
-        } elseif ("'self' data: https:" === $choice) {
+        } elseif ($choice === "'self' data: https:") {
             $builder->imgSrc("'self'", 'data:', 'https:');
         } else {
             $custom = $this->ask('Enter custom img-src values (space-separated)');
@@ -321,9 +321,9 @@ class GenerateCspPolicy extends Command
      */
     protected function applyFontChoice(CspPolicyBuilder $builder, string $choice): void
     {
-        if ("'self'" === $choice) {
+        if ($choice === "'self'") {
             $builder->fontSrc("'self'");
-        } elseif ("'self' data:" === $choice) {
+        } elseif ($choice === "'self' data:") {
             $builder->fontSrc("'self'", 'data:');
         } elseif (str_contains($choice, 'fonts.gstatic.com')) {
             $builder->fontSrc("'self'", 'https://fonts.gstatic.com', 'https://fonts.bunny.net');
@@ -354,12 +354,12 @@ class GenerateCspPolicy extends Command
     protected function analyzeApplication(): void
     {
         $this->detectedSources = [
-            'script-src'  => [],
-            'style-src'   => [],
-            'img-src'     => [],
-            'font-src'    => [],
+            'script-src' => [],
+            'style-src' => [],
+            'img-src' => [],
+            'font-src' => [],
             'connect-src' => [],
-            'frame-src'   => [],
+            'frame-src' => [],
         ];
 
         $viewsPath = resource_path('views');
@@ -371,7 +371,7 @@ class GenerateCspPolicy extends Command
         $files = File::allFiles($viewsPath);
 
         foreach ($files as $file) {
-            if ('php' !== $file->getExtension()) {
+            if ($file->getExtension() !== 'php') {
                 continue;
             }
 
@@ -459,7 +459,7 @@ class GenerateCspPolicy extends Command
         if (str_starts_with($source, 'http://') || str_starts_with($source, 'https://') || str_starts_with($source, '//')) {
             $parsed = parse_url($source);
             if (isset($parsed['host'])) {
-                $scheme                              = $parsed['scheme'] ?? 'https';
+                $scheme = $parsed['scheme'] ?? 'https';
                 $this->detectedSources[$directive][] = "{$scheme}://{$parsed['host']}";
             }
         } elseif (str_starts_with($source, 'data:')) {
@@ -491,7 +491,7 @@ class GenerateCspPolicy extends Command
         // Check package.json for common CDN-based packages
         $packageJson = base_path('package.json');
         if (File::exists($packageJson)) {
-            $package      = json_decode(File::get($packageJson), true);
+            $package = json_decode(File::get($packageJson), true);
             $dependencies = array_merge(
                 $package['dependencies'] ?? [],
                 $package['devDependencies'] ?? [],
@@ -543,17 +543,17 @@ class GenerateCspPolicy extends Command
     protected function formatOutput(string $policy, string $format): string
     {
         $isReportOnly = $this->option('report-only');
-        $headerName   = $isReportOnly ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
+        $headerName = $isReportOnly ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
 
         return match ($format) {
             'header' => "{$headerName}: {$policy}",
-            'meta'   => '<meta http-equiv="'.$headerName.'" content="'.htmlspecialchars($policy, ENT_QUOTES).'">',
-            'nginx'  => "add_header {$headerName} \"{$policy}\" always;",
+            'meta' => '<meta http-equiv="'.$headerName.'" content="'.htmlspecialchars($policy, ENT_QUOTES).'">',
+            'nginx' => "add_header {$headerName} \"{$policy}\" always;",
             'apache' => "Header always set {$headerName} \"{$policy}\"",
-            'json'   => json_encode([
+            'json' => json_encode([
                 'header_name' => $headerName,
-                'policy'      => $policy,
-                'directives'  => $this->parseDirectives($policy),
+                'policy' => $policy,
+                'directives' => $this->parseDirectives($policy),
                 'report_only' => $isReportOnly,
             ], JSON_PRETTY_PRINT),
             default => $this->formatAsConfig($policy, $isReportOnly), // 'config'
@@ -596,7 +596,7 @@ class GenerateCspPolicy extends Command
     protected function parseDirectives(string $policy): array
     {
         $directives = [];
-        $parts      = explode(';', $policy);
+        $parts = explode(';', $policy);
 
         foreach ($parts as $part) {
             $part = trim($part);
@@ -605,10 +605,10 @@ class GenerateCspPolicy extends Command
             }
 
             $tokens = preg_split('/\s+/', $part);
-            if (false === $tokens) {
+            if ($tokens === false) {
                 continue;
             }
-            $directive              = array_shift($tokens);
+            $directive = array_shift($tokens);
             $directives[$directive] = $tokens;
         }
 
@@ -623,7 +623,7 @@ class GenerateCspPolicy extends Command
         $this->info("Generated Policy ({$format} format):");
         $this->newLine();
 
-        if ('json' === $format) {
+        if ($format === 'json') {
             $this->line($output);
         } else {
             $this->line('<fg=yellow>'.$output.'</>');
@@ -641,7 +641,7 @@ class GenerateCspPolicy extends Command
         $this->info('Recommendations:');
 
         $recommendations = [];
-        $directives      = $this->parseDirectives($policy);
+        $directives = $this->parseDirectives($policy);
 
         // Check for unsafe-inline without nonce
         if (isset($directives['script-src'])) {

--- a/src/Console/Commands/ScanDependencies.php
+++ b/src/Console/Commands/ScanDependencies.php
@@ -49,10 +49,10 @@ class ScanDependencies extends Command
      * @var array<string, int>
      */
     protected array $severityLevels = [
-        'info'     => 0,
-        'low'      => 1,
-        'medium'   => 2,
-        'high'     => 3,
+        'info' => 0,
+        'low' => 1,
+        'medium' => 2,
+        'high' => 3,
         'critical' => 4,
     ];
 
@@ -65,16 +65,16 @@ class ScanDependencies extends Command
         $this->newLine();
 
         $scanComposer = ! $this->option('npm');
-        $scanNpm      = ! $this->option('composer');
+        $scanNpm = ! $this->option('composer');
 
         // If both flags are set, scan both
         if ($this->option('composer') && $this->option('npm')) {
             $scanComposer = true;
-            $scanNpm      = true;
+            $scanNpm = true;
         }
 
         $composerLock = $scanComposer ? base_path('composer.lock') : null;
-        $packageLock  = $scanNpm ? base_path('package-lock.json') : null;
+        $packageLock = $scanNpm ? base_path('package-lock.json') : null;
 
         // Check if files exist
         if ($scanComposer && ! File::exists(base_path('composer.lock'))) {
@@ -87,7 +87,7 @@ class ScanDependencies extends Command
             $packageLock = null;
         }
 
-        if (null === $composerLock && null === $packageLock) {
+        if ($composerLock === null && $packageLock === null) {
             $this->error('No lock files found to scan.');
 
             return self::FAILURE;
@@ -164,7 +164,6 @@ class ScanDependencies extends Command
      * Filter findings by minimum severity.
      *
      * @param  array<SecurityFinding>  $findings
-     *
      * @return array<SecurityFinding>
      */
     protected function filterBySeverity(array $findings): array
@@ -178,7 +177,7 @@ class ScanDependencies extends Command
 
         return array_filter($findings, function ($finding) use ($minLevel) {
             $findingSeverity = strtolower($finding->severity ?? 'info');
-            $findingLevel    = $this->severityLevels[$findingSeverity] ?? 0;
+            $findingLevel = $this->severityLevels[$findingSeverity] ?? 0;
 
             return $findingLevel >= $minLevel;
         });
@@ -192,7 +191,7 @@ class ScanDependencies extends Command
     protected function formatOutput(array $findings, string $format): string
     {
         return match ($format) {
-            'json'  => $this->formatAsJson($findings),
+            'json' => $this->formatAsJson($findings),
             'sarif' => $this->formatAsSarif($findings),
             default => $this->formatAsText($findings),
         };
@@ -206,16 +205,16 @@ class ScanDependencies extends Command
     protected function formatAsJson(array $findings): string
     {
         $data = [
-            'scan_date'      => now()->toIso8601String(),
+            'scan_date' => now()->toIso8601String(),
             'total_findings' => count($findings),
-            'summary'        => $this->getSummary($findings),
-            'findings'       => array_map(fn ($f) => [
-                'id'          => $f->id ?? null,
-                'title'       => $f->title ?? '',
+            'summary' => $this->getSummary($findings),
+            'findings' => array_map(fn ($f) => [
+                'id' => $f->id ?? null,
+                'title' => $f->title ?? '',
                 'description' => $f->description ?? '',
-                'severity'    => $f->severity ?? 'unknown',
-                'category'    => $f->category ?? '',
-                'location'    => $f->location ?? '',
+                'severity' => $f->severity ?? 'unknown',
+                'category' => $f->category ?? '',
+                'location' => $f->location ?? '',
                 'remediation' => $f->remediation ?? '',
             ], $findings),
         ];
@@ -234,8 +233,8 @@ class ScanDependencies extends Command
 
         foreach ($findings as $finding) {
             $results[] = [
-                'ruleId'  => $finding->id ?? 'UNKNOWN',
-                'level'   => $this->sarifLevel($finding->severity ?? 'info'),
+                'ruleId' => $finding->id ?? 'UNKNOWN',
+                'level' => $this->sarifLevel($finding->severity ?? 'info'),
                 'message' => [
                     'text' => ($finding->title ?? '').' - '.($finding->description ?? ''),
                 ],
@@ -254,11 +253,11 @@ class ScanDependencies extends Command
         $sarif = [
             '$schema' => 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
             'version' => '2.1.0',
-            'runs'    => [
+            'runs' => [
                 [
                     'tool' => [
                         'driver' => [
-                            'name'    => 'ArtisanPackUI Security - Dependency Scanner',
+                            'name' => 'ArtisanPackUI Security - Dependency Scanner',
                             'version' => '2.0.0',
                         ],
                     ],
@@ -277,8 +276,8 @@ class ScanDependencies extends Command
     {
         return match (strtolower($severity)) {
             'critical', 'high' => 'error',
-            'medium'           => 'warning',
-            default            => 'note',
+            'medium' => 'warning',
+            default => 'note',
         };
     }
 
@@ -301,7 +300,7 @@ class ScanDependencies extends Command
 
         // Group by source type
         $composer = [];
-        $npm      = [];
+        $npm = [];
 
         foreach ($findings as $finding) {
             $location = $finding->location ?? '';
@@ -348,7 +347,7 @@ class ScanDependencies extends Command
     protected function formatFindingText(SecurityFinding $finding): string
     {
         $severity = strtoupper($finding->severity ?? 'UNKNOWN');
-        $output   = " x {$finding->location}\n";
+        $output = " x {$finding->location}\n";
         $output .= "   {$finding->id} ({$severity}): {$finding->title}\n";
         if ($finding->remediation) {
             $output .= "   Fix: {$finding->remediation}\n";
@@ -396,7 +395,7 @@ class ScanDependencies extends Command
 
         // Group findings
         $composerFindings = [];
-        $npmFindings      = [];
+        $npmFindings = [];
 
         foreach ($findings as $finding) {
             $location = $finding->location ?? '';
@@ -430,10 +429,10 @@ class ScanDependencies extends Command
         foreach ($findings as $finding) {
             $severityColor = match (strtolower($finding->severity ?? 'info')) {
                 'critical' => 'red',
-                'high'     => 'yellow',
-                'medium'   => 'blue',
-                'low'      => 'cyan',
-                default    => 'gray',
+                'high' => 'yellow',
+                'medium' => 'blue',
+                'low' => 'cyan',
+                default => 'gray',
             };
 
             $rows[] = [
@@ -452,18 +451,17 @@ class ScanDependencies extends Command
      * Get summary counts.
      *
      * @param  array<SecurityFinding>  $findings
-     *
      * @return array<string, int>
      */
     protected function getSummary(array $findings): array
     {
         $summary = [
             'critical' => 0,
-            'high'     => 0,
-            'medium'   => 0,
-            'low'      => 0,
-            'info'     => 0,
-            'total'    => count($findings),
+            'high' => 0,
+            'medium' => 0,
+            'low' => 0,
+            'info' => 0,
+            'total' => count($findings),
         ];
 
         foreach ($findings as $finding) {
@@ -499,7 +497,7 @@ class ScanDependencies extends Command
     {
         $failOn = $this->option('fail-on');
 
-        if ('none' === $failOn) {
+        if ($failOn === 'none') {
             return self::SUCCESS;
         }
 
@@ -507,7 +505,7 @@ class ScanDependencies extends Command
 
         foreach ($findings as $finding) {
             $findingSeverity = strtolower($finding->severity ?? 'info');
-            $findingLevel    = $this->severityLevels[$findingSeverity] ?? 0;
+            $findingLevel = $this->severityLevels[$findingSeverity] ?? 0;
 
             if ($findingLevel >= $failLevel) {
                 $this->newLine();

--- a/src/Console/Commands/SecurityAudit.php
+++ b/src/Console/Commands/SecurityAudit.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ArtisanPackUI\Security\Console\Commands;
 
 use ArtisanPackUI\Security\Testing\CiCd\SecurityGate;
+use ArtisanPackUI\Security\Testing\Performance\BenchmarkResult;
 use ArtisanPackUI\Security\Testing\Performance\ImpactAnalyzer;
 use ArtisanPackUI\Security\Testing\Performance\SecurityBenchmark;
 use ArtisanPackUI\Security\Testing\Reporting\SecurityFinding;
@@ -46,10 +47,10 @@ class SecurityAudit extends Command
      * @var array<string, string>
      */
     protected array $availableScanners = [
-        'owasp'        => 'OWASP Top 10 Scanner',
+        'owasp' => 'OWASP Top 10 Scanner',
         'dependencies' => 'Dependency Scanner',
-        'config'       => 'Configuration Scanner',
-        'headers'      => 'Security Headers Scanner',
+        'config' => 'Configuration Scanner',
+        'headers' => 'Security Headers Scanner',
     ];
 
     /**
@@ -58,10 +59,10 @@ class SecurityAudit extends Command
      * @var array<string, int>
      */
     protected array $severityLevels = [
-        'info'     => 0,
-        'low'      => 1,
-        'medium'   => 2,
-        'high'     => 3,
+        'info' => 0,
+        'low' => 1,
+        'medium' => 2,
+        'high' => 3,
         'critical' => 4,
     ];
 
@@ -75,7 +76,7 @@ class SecurityAudit extends Command
         }
 
         $startTime = microtime(true);
-        $findings  = [];
+        $findings = [];
 
         // Determine which scanners to run
         $scannersToRun = $this->getScannersToRun();
@@ -83,7 +84,7 @@ class SecurityAudit extends Command
         // Run selected scanners
         if (in_array('owasp', $scannersToRun, true)) {
             $this->runTask('OWASP Top 10 Scanner', function () use (&$findings) {
-                $scanner  = new OwaspScanner;
+                $scanner = new OwaspScanner;
                 $findings = array_merge($findings, $scanner->scan());
 
                 return true;
@@ -92,7 +93,7 @@ class SecurityAudit extends Command
 
         if (in_array('dependencies', $scannersToRun, true)) {
             $this->runTask('Dependency Scanner', function () use (&$findings) {
-                $scanner  = new DependencyScanner;
+                $scanner = new DependencyScanner;
                 $findings = array_merge($findings, $scanner->scan());
 
                 return true;
@@ -101,7 +102,7 @@ class SecurityAudit extends Command
 
         if (in_array('config', $scannersToRun, true)) {
             $this->runTask('Configuration Scanner', function () use (&$findings) {
-                $scanner  = new ConfigurationScanner;
+                $scanner = new ConfigurationScanner;
                 $findings = array_merge($findings, $scanner->scan());
 
                 return true;
@@ -111,7 +112,7 @@ class SecurityAudit extends Command
         if (in_array('headers', $scannersToRun, true)) {
             $this->runTask('Security Headers Scanner', function () use (&$findings) {
                 $headerFindings = $this->runHeadersScanner();
-                $findings       = array_merge($findings, $headerFindings);
+                $findings = array_merge($findings, $headerFindings);
 
                 return true;
             }, $silent);
@@ -121,16 +122,16 @@ class SecurityAudit extends Command
         $benchmarkResults = [];
         if ($this->option('benchmark')) {
             $this->runTask('Performance Benchmarks', function () use (&$benchmarkResults) {
-                $benchmark        = new SecurityBenchmark;
+                $benchmark = new SecurityBenchmark;
                 $benchmarkResults = $benchmark->runFullSuite();
 
                 return true;
             }, $silent);
 
             // Analyze performance impact
-            $analyzer            = new ImpactAnalyzer($benchmarkResults);
+            $analyzer = new ImpactAnalyzer($benchmarkResults);
             $performanceFindings = $analyzer->analyze();
-            $findings            = array_merge($findings, $performanceFindings);
+            $findings = array_merge($findings, $performanceFindings);
         }
 
         // Filter by severity if specified
@@ -145,9 +146,9 @@ class SecurityAudit extends Command
         );
 
         $metadata = [
-            'auditDuration'      => $duration,
+            'auditDuration' => $duration,
             'benchmarksIncluded' => $this->option('benchmark'),
-            'scannersRun'        => $scannersToRun,
+            'scannersRun' => $scannersToRun,
         ];
 
         if ($this->option('include-recommendations')) {
@@ -164,7 +165,7 @@ class SecurityAudit extends Command
         // Output results
         if ($outputPath = $this->option('output')) {
             $result = file_put_contents($outputPath, $output);
-            if (false === $result) {
+            if ($result === false) {
                 $this->error("Failed to write report to: {$outputPath}");
             } elseif (! $silent) {
                 $this->info("Report saved to: {$outputPath}");
@@ -236,11 +237,11 @@ class SecurityAudit extends Command
                 $task();
             } catch (Throwable $e) {
                 Log::error("Security audit task '{$title}' failed: {$e->getMessage()}", [
-                    'task'      => $title,
+                    'task' => $title,
                     'exception' => get_class($e),
-                    'message'   => $e->getMessage(),
-                    'file'      => $e->getFile(),
-                    'line'      => $e->getLine(),
+                    'message' => $e->getMessage(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
                 ]);
             }
 
@@ -257,7 +258,7 @@ class SecurityAudit extends Command
      */
     protected function runHeadersScanner(): array
     {
-        $findings          = [];
+        $findings = [];
         $configuredHeaders = config('artisanpack.security.security-headers', []);
 
         $requiredHeaders = [
@@ -282,12 +283,12 @@ class SecurityAudit extends Command
         foreach ($requiredHeaders as $header => $config) {
             if (empty($configuredHeaders[$header])) {
                 $findings[] = SecurityFinding::fromArray([
-                    'id'          => 'HEADERS-'.strtoupper(str_replace('-', '', $header)),
-                    'title'       => "Missing {$header} header",
+                    'id' => 'HEADERS-'.strtoupper(str_replace('-', '', $header)),
+                    'title' => "Missing {$header} header",
                     'description' => "The {$header} security header is not configured",
-                    'severity'    => $config['severity'],
-                    'category'    => $config['category'],
-                    'location'    => 'config/artisanpack/security.php',
+                    'severity' => $config['severity'],
+                    'category' => $config['category'],
+                    'location' => 'config/artisanpack/security.php',
                     'remediation' => "Add {$header} to security-headers configuration",
                 ]);
             }
@@ -297,24 +298,24 @@ class SecurityAudit extends Command
         $csp = $configuredHeaders['Content-Security-Policy'] ?? '';
         if ($csp && str_contains($csp, "'unsafe-inline'") && ! str_contains($csp, "'strict-dynamic'")) {
             $findings[] = SecurityFinding::fromArray([
-                'id'          => 'HEADERS-CSP-UNSAFE-INLINE',
-                'title'       => 'CSP uses unsafe-inline',
+                'id' => 'HEADERS-CSP-UNSAFE-INLINE',
+                'title' => 'CSP uses unsafe-inline',
                 'description' => "Content-Security-Policy contains 'unsafe-inline' without strict-dynamic",
-                'severity'    => 'medium',
-                'category'    => 'Security Headers',
-                'location'    => 'config/artisanpack/security.php',
+                'severity' => 'medium',
+                'category' => 'Security Headers',
+                'location' => 'config/artisanpack/security.php',
                 'remediation' => "Consider using nonces or 'strict-dynamic' instead of 'unsafe-inline'",
             ]);
         }
 
         if ($csp && str_contains($csp, "'unsafe-eval'")) {
             $findings[] = SecurityFinding::fromArray([
-                'id'          => 'HEADERS-CSP-UNSAFE-EVAL',
-                'title'       => 'CSP uses unsafe-eval',
+                'id' => 'HEADERS-CSP-UNSAFE-EVAL',
+                'title' => 'CSP uses unsafe-eval',
                 'description' => "Content-Security-Policy contains 'unsafe-eval' which allows eval()",
-                'severity'    => 'medium',
-                'category'    => 'Security Headers',
-                'location'    => 'config/artisanpack/security.php',
+                'severity' => 'medium',
+                'category' => 'Security Headers',
+                'location' => 'config/artisanpack/security.php',
                 'remediation' => "Remove 'unsafe-eval' if not required by your framework",
             ]);
         }
@@ -326,7 +327,6 @@ class SecurityAudit extends Command
      * Filter findings by minimum severity.
      *
      * @param  array<SecurityFinding>  $findings
-     *
      * @return array<SecurityFinding>
      */
     protected function filterBySeverity(array $findings): array
@@ -340,7 +340,7 @@ class SecurityAudit extends Command
 
         return array_filter($findings, function ($finding) use ($minLevel) {
             $findingSeverity = strtolower($finding->severity ?? 'info');
-            $findingLevel    = $this->severityLevels[$findingSeverity] ?? 0;
+            $findingLevel = $this->severityLevels[$findingSeverity] ?? 0;
 
             return $findingLevel >= $minLevel;
         });
@@ -358,8 +358,8 @@ class SecurityAudit extends Command
         foreach ($findings as $finding) {
             if (! empty($finding->remediation)) {
                 $recommendations[] = [
-                    'severity'    => $finding->severity ?? 'info',
-                    'title'       => $finding->title ?? 'Unknown',
+                    'severity' => $finding->severity ?? 'info',
+                    'title' => $finding->title ?? 'Unknown',
                     'remediation' => $finding->remediation,
                 ];
             }
@@ -381,9 +381,9 @@ class SecurityAudit extends Command
         foreach (array_slice($recommendations, 0, 10) as $i => $rec) {
             $severityColor = match ($rec['severity']) {
                 'critical' => 'red',
-                'high'     => 'yellow',
-                'medium'   => 'blue',
-                default    => 'cyan',
+                'high' => 'yellow',
+                'medium' => 'blue',
+                default => 'cyan',
             };
 
             $this->line(($i + 1).". <fg={$severityColor}>[{$rec['severity']}]</> {$rec['title']}");
@@ -415,7 +415,7 @@ class SecurityAudit extends Command
      * Display audit results.
      *
      * @param  array<string, mixed>  $summary
-     * @param  array<\ArtisanPackUI\Security\Testing\Performance\BenchmarkResult>  $benchmarks
+     * @param  array<BenchmarkResult>  $benchmarks
      */
     protected function displayResults(array $summary, array $benchmarks, float $duration): void
     {
@@ -431,10 +431,10 @@ class SecurityAudit extends Command
         foreach ($summary['bySeverity'] as $severity => $count) {
             $color = match ($severity) {
                 'critical' => 'red',
-                'high'     => 'yellow',
-                'medium'   => 'blue',
-                'low'      => 'cyan',
-                default    => 'gray',
+                'high' => 'yellow',
+                'medium' => 'blue',
+                'low' => 'cyan',
+                default => 'gray',
             };
             $rows[] = ["<fg={$color}>".ucfirst($severity).'</>', $count];
         }

--- a/src/Console/Commands/SecurityBaseline.php
+++ b/src/Console/Commands/SecurityBaseline.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ArtisanPackUI\Security\Console\Commands;
 
+use ArtisanPackUI\Security\Testing\Reporting\SecurityFinding;
 use ArtisanPackUI\Security\Testing\Scanners\ConfigurationScanner;
 use ArtisanPackUI\Security\Testing\Scanners\DependencyScanner;
 use ArtisanPackUI\Security\Testing\Scanners\OwaspScanner;
@@ -37,14 +38,14 @@ class SecurityBaseline extends Command
     public function handle(): int
     {
         $action = $this->argument('action');
-        $path   = $this->option('path') ?? $this->defaultPath;
+        $path = $this->option('path') ?? $this->defaultPath;
 
         return match ($action) {
-            'show'   => $this->showBaseline($path),
+            'show' => $this->showBaseline($path),
             'create' => $this->createBaseline($path),
             'update' => $this->updateBaseline($path),
-            'clear'  => $this->clearBaseline($path),
-            default  => $this->invalidAction($action),
+            'clear' => $this->clearBaseline($path),
+            default => $this->invalidAction($action),
         };
     }
 
@@ -62,7 +63,7 @@ class SecurityBaseline extends Command
 
         $baseline = json_decode(file_get_contents($path), true);
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
             $this->error('Invalid baseline file format.');
 
             return self::FAILURE;
@@ -115,14 +116,14 @@ class SecurityBaseline extends Command
             'metadata' => [
                 'createdAt' => now()->toIso8601String(),
                 'updatedAt' => now()->toIso8601String(),
-                'version'   => '1.0',
+                'version' => '1.0',
             ],
             'findings' => array_map(fn ($f) => $f->toArray(), $findings),
         ];
 
         $result = file_put_contents($path, json_encode($baseline, JSON_PRETTY_PRINT));
 
-        if (false === $result) {
+        if ($result === false) {
             $this->error("Failed to write baseline file: {$path}");
 
             return self::FAILURE;
@@ -146,7 +147,7 @@ class SecurityBaseline extends Command
 
         $this->info('Running security scan...');
 
-        $findings    = $this->runScan();
+        $findings = $this->runScan();
         $newFindings = [];
         $existingIds = array_column($existingBaseline['findings'] ?? [], 'id');
 
@@ -178,7 +179,7 @@ class SecurityBaseline extends Command
             'metadata' => [
                 'createdAt' => $existingBaseline['metadata']['createdAt'] ?? now()->toIso8601String(),
                 'updatedAt' => now()->toIso8601String(),
-                'version'   => '1.0',
+                'version' => '1.0',
             ],
             'findings' => array_merge(
                 $existingBaseline['findings'] ?? [],
@@ -230,24 +231,24 @@ class SecurityBaseline extends Command
     /**
      * Run security scan and return findings.
      *
-     * @return array<\ArtisanPackUI\Security\Testing\Reporting\SecurityFinding>
+     * @return array<SecurityFinding>
      */
     protected function runScan(): array
     {
         $findings = [];
 
         $this->output->write('  OWASP scan... ');
-        $scanner  = new OwaspScanner;
+        $scanner = new OwaspScanner;
         $findings = array_merge($findings, $scanner->scan());
         $this->output->writeln('<fg=green>done</>');
 
         $this->output->write('  Dependency scan... ');
-        $scanner  = new DependencyScanner;
+        $scanner = new DependencyScanner;
         $findings = array_merge($findings, $scanner->scan());
         $this->output->writeln('<fg=green>done</>');
 
         $this->output->write('  Configuration scan... ');
-        $scanner  = new ConfigurationScanner;
+        $scanner = new ConfigurationScanner;
         $findings = array_merge($findings, $scanner->scan());
         $this->output->writeln('<fg=green>done</>');
 

--- a/src/Console/Commands/SecurityBenchmarkCommand.php
+++ b/src/Console/Commands/SecurityBenchmarkCommand.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace ArtisanPackUI\Security\Console\Commands;
 
+use ArtisanPackUI\Security\Http\Middleware\ContentSecurityPolicy;
+use ArtisanPackUI\Security\Http\Middleware\SecurityHeaders;
+use ArtisanPackUI\Security\Testing\Performance\BenchmarkResult;
 use ArtisanPackUI\Security\Testing\Performance\ImpactAnalyzer;
 use ArtisanPackUI\Security\Testing\Performance\SecurityBenchmark;
 use Exception;
@@ -31,7 +34,7 @@ class SecurityBenchmarkCommand extends Command
     public function handle(): int
     {
         $iterations = (int) $this->option('iterations');
-        $threshold  = (float) $this->option('threshold');
+        $threshold = (float) $this->option('threshold');
 
         $this->info('Running security performance benchmarks...');
         $this->line("Iterations: {$iterations}");
@@ -60,8 +63,8 @@ class SecurityBenchmarkCommand extends Command
 
         // Benchmark middleware if available
         $middlewareClasses = [
-            \ArtisanPackUI\Security\Http\Middleware\SecurityHeaders::class,
-            \ArtisanPackUI\Security\Http\Middleware\ContentSecurityPolicy::class,
+            SecurityHeaders::class,
+            ContentSecurityPolicy::class,
         ];
 
         foreach ($middlewareClasses as $middlewareClass) {
@@ -77,15 +80,15 @@ class SecurityBenchmarkCommand extends Command
 
         // Analyze results
         $analyzer = new ImpactAnalyzer($results, ['default' => $threshold]);
-        $summary  = $analyzer->getSummary();
+        $summary = $analyzer->getSummary();
 
         // Output results
         $format = $this->option('format');
 
-        if ('json' === $format) {
+        if ($format === 'json') {
             $output = json_encode([
-                'results'         => $benchmark->generateReport(),
-                'summary'         => $summary,
+                'results' => $benchmark->generateReport(),
+                'summary' => $summary,
                 'recommendations' => $analyzer->getRecommendations(),
             ], JSON_PRETTY_PRINT);
 
@@ -140,7 +143,7 @@ class SecurityBenchmarkCommand extends Command
     /**
      * Display results as a table.
      *
-     * @param  array<\ArtisanPackUI\Security\Testing\Performance\BenchmarkResult>  $results
+     * @param  array<BenchmarkResult>  $results
      * @param  array<string, mixed>  $summary
      */
     protected function displayTable(array $results, array $summary): void
@@ -169,7 +172,7 @@ class SecurityBenchmarkCommand extends Command
         $this->newLine();
         $this->line(sprintf(
             'Pass rate: <fg=%s>%.1f%%</> (%d/%d)',
-            100 === $summary['pass_rate'] ? 'green' : 'yellow',
+            $summary['pass_rate'] === 100 ? 'green' : 'yellow',
             $summary['pass_rate'],
             $summary['acceptable'],
             $summary['total_benchmarks'],

--- a/src/Console/Commands/SecurityScan.php
+++ b/src/Console/Commands/SecurityScan.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ArtisanPackUI\Security\Console\Commands;
 
+use ArtisanPackUI\Security\Testing\Reporting\SecurityFinding;
 use ArtisanPackUI\Security\Testing\Reporting\SecurityReportGenerator;
 use ArtisanPackUI\Security\Testing\Scanners\ConfigurationScanner;
 use ArtisanPackUI\Security\Testing\Scanners\DependencyScanner;
@@ -38,48 +39,48 @@ class SecurityScan extends Command
         $this->newLine();
 
         $findings = [];
-        $type     = $this->option('type');
+        $type = $this->option('type');
 
         // Run scanners based on type
-        if ('all' === $type || 'owasp' === $type) {
+        if ($type === 'all' || $type === 'owasp') {
             $this->info('Running OWASP Top 10 scan...');
             $categories = $this->option('categories')
                 ? explode(',', $this->option('categories'))
                 : [];
-            $scanner       = new OwaspScanner($categories);
+            $scanner = new OwaspScanner($categories);
             $owaspFindings = $scanner->scan();
-            $findings      = array_merge($findings, $owaspFindings);
+            $findings = array_merge($findings, $owaspFindings);
             $this->line("  Found {$this->countFindings($owaspFindings)} issues");
         }
 
-        if ('all' === $type || 'dependencies' === $type) {
+        if ($type === 'all' || $type === 'dependencies') {
             $this->info('Running dependency scan...');
-            $scanner     = new DependencyScanner;
+            $scanner = new DependencyScanner;
             $depFindings = $scanner->scan();
-            $findings    = array_merge($findings, $depFindings);
+            $findings = array_merge($findings, $depFindings);
             $this->line("  Found {$this->countFindings($depFindings)} issues");
         }
 
-        if ('all' === $type || 'config' === $type) {
+        if ($type === 'all' || $type === 'config') {
             $this->info('Running configuration scan...');
-            $scanner        = new ConfigurationScanner;
+            $scanner = new ConfigurationScanner;
             $configFindings = $scanner->scan();
-            $findings       = array_merge($findings, $configFindings);
+            $findings = array_merge($findings, $configFindings);
             $this->line("  Found {$this->countFindings($configFindings)} issues");
         }
 
-        if ('all' === $type || 'headers' === $type) {
+        if ($type === 'all' || $type === 'headers') {
             $this->info('Running security headers scan...');
-            $scanner        = new HeaderScanner;
+            $scanner = new HeaderScanner;
             $headerFindings = $scanner->scan();
-            $findings       = array_merge($findings, $headerFindings);
+            $findings = array_merge($findings, $headerFindings);
             $this->line("  Found {$this->countFindings($headerFindings)} issues");
         }
 
         // Apply baseline if provided
         if ($baseline = $this->option('baseline')) {
             $originalCount = count($findings);
-            $findings      = $this->applyBaseline($findings, $baseline);
+            $findings = $this->applyBaseline($findings, $baseline);
             $filteredCount = $originalCount - count($findings);
 
             if ($filteredCount > 0) {
@@ -100,7 +101,7 @@ class SecurityScan extends Command
         // Output results
         if ($outputPath = $this->option('output')) {
             $bytes = @file_put_contents($outputPath, $output);
-            if (false === $bytes) {
+            if ($bytes === false) {
                 $this->error("Failed to save report to: {$outputPath}");
 
                 return self::FAILURE;
@@ -121,7 +122,7 @@ class SecurityScan extends Command
     /**
      * Count findings in an array.
      *
-     * @param  array<\ArtisanPackUI\Security\Testing\Reporting\SecurityFinding>  $findings
+     * @param  array<SecurityFinding>  $findings
      */
     protected function countFindings(array $findings): int
     {
@@ -143,11 +144,11 @@ class SecurityScan extends Command
         foreach ($summary['bySeverity'] as $severity => $count) {
             $icon = match ($severity) {
                 'critical' => '<fg=red>●</>',
-                'high'     => '<fg=yellow>●</>',
-                'medium'   => '<fg=blue>●</>',
-                'low'      => '<fg=cyan>●</>',
-                'info'     => '<fg=gray>●</>',
-                default    => '●',
+                'high' => '<fg=yellow>●</>',
+                'medium' => '<fg=blue>●</>',
+                'low' => '<fg=cyan>●</>',
+                'info' => '<fg=gray>●</>',
+                default => '●',
             };
             $rows[] = [$icon.' '.ucfirst($severity), $count];
         }
@@ -161,15 +162,15 @@ class SecurityScan extends Command
     /**
      * Determine exit code based on findings.
      *
-     * @param  array<\ArtisanPackUI\Security\Testing\Reporting\SecurityFinding>  $findings
+     * @param  array<SecurityFinding>  $findings
      */
     protected function determineExitCode(array $findings): int
     {
-        $failOn        = $this->option('fail-on');
+        $failOn = $this->option('fail-on');
         $severityOrder = ['critical', 'high', 'medium', 'low', 'info'];
-        $threshold     = array_search($failOn, $severityOrder);
+        $threshold = array_search($failOn, $severityOrder);
 
-        if (false === $threshold) {
+        if ($threshold === false) {
             $this->warn("Invalid --fail-on value: {$failOn}. Using 'high' as default.");
             $threshold = array_search('high', $severityOrder);
         }
@@ -177,7 +178,7 @@ class SecurityScan extends Command
         foreach ($findings as $finding) {
             $findingSeverity = array_search($finding->severity, $severityOrder);
 
-            if (false !== $findingSeverity && false !== $threshold && $findingSeverity <= $threshold) {
+            if ($findingSeverity !== false && $threshold !== false && $findingSeverity <= $threshold) {
                 $this->newLine();
                 $this->error("Scan failed: Found {$finding->severity} severity issue(s)");
 
@@ -194,9 +195,8 @@ class SecurityScan extends Command
     /**
      * Apply baseline to filter known issues.
      *
-     * @param  array<\ArtisanPackUI\Security\Testing\Reporting\SecurityFinding>  $findings
-     *
-     * @return array<\ArtisanPackUI\Security\Testing\Reporting\SecurityFinding>
+     * @param  array<SecurityFinding>  $findings
+     * @return array<SecurityFinding>
      */
     protected function applyBaseline(array $findings, string $baselinePath): array
     {
@@ -207,7 +207,7 @@ class SecurityScan extends Command
         }
 
         $content = @file_get_contents($baselinePath);
-        if (false === $content) {
+        if ($content === false) {
             $this->warn("Unable to read baseline file: {$baselinePath}");
 
             return $findings;
@@ -215,7 +215,7 @@ class SecurityScan extends Command
 
         $baseline = json_decode($content, true);
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
             $this->warn('Invalid baseline file format');
 
             return $findings;

--- a/src/Console/Commands/TestSecurityHeaders.php
+++ b/src/Console/Commands/TestSecurityHeaders.php
@@ -47,64 +47,64 @@ class TestSecurityHeaders extends Command
      */
     protected array $headerRules = [
         'Strict-Transport-Security' => [
-            'required'    => true,
-            'severity'    => 'high',
+            'required' => true,
+            'severity' => 'high',
             'recommended' => 'max-age=31536000; includeSubDomains',
-            'validate'    => 'validateHsts',
+            'validate' => 'validateHsts',
         ],
         'X-Frame-Options' => [
-            'required'    => true,
-            'severity'    => 'high',
+            'required' => true,
+            'severity' => 'high',
             'recommended' => 'SAMEORIGIN',
-            'validate'    => 'validateXFrameOptions',
+            'validate' => 'validateXFrameOptions',
         ],
         'X-Content-Type-Options' => [
-            'required'    => true,
-            'severity'    => 'medium',
+            'required' => true,
+            'severity' => 'medium',
             'recommended' => 'nosniff',
-            'validate'    => 'validateXContentTypeOptions',
+            'validate' => 'validateXContentTypeOptions',
         ],
         'Content-Security-Policy' => [
-            'required'    => true,
-            'severity'    => 'high',
+            'required' => true,
+            'severity' => 'high',
             'recommended' => null,
-            'validate'    => 'validateCsp',
+            'validate' => 'validateCsp',
         ],
         'X-XSS-Protection' => [
-            'required'    => false,
-            'severity'    => 'low',
+            'required' => false,
+            'severity' => 'low',
             'recommended' => '1; mode=block',
-            'validate'    => 'validateXssProtection',
+            'validate' => 'validateXssProtection',
         ],
         'Referrer-Policy' => [
-            'required'    => false,
-            'severity'    => 'medium',
+            'required' => false,
+            'severity' => 'medium',
             'recommended' => 'strict-origin-when-cross-origin',
-            'validate'    => 'validateReferrerPolicy',
+            'validate' => 'validateReferrerPolicy',
         ],
         'Permissions-Policy' => [
-            'required'    => false,
-            'severity'    => 'medium',
+            'required' => false,
+            'severity' => 'medium',
             'recommended' => null,
-            'validate'    => 'validatePermissionsPolicy',
+            'validate' => 'validatePermissionsPolicy',
         ],
         'Cross-Origin-Opener-Policy' => [
-            'required'    => false,
-            'severity'    => 'medium',
+            'required' => false,
+            'severity' => 'medium',
             'recommended' => 'same-origin',
-            'validate'    => 'validateCoop',
+            'validate' => 'validateCoop',
         ],
         'Cross-Origin-Resource-Policy' => [
-            'required'    => false,
-            'severity'    => 'medium',
+            'required' => false,
+            'severity' => 'medium',
             'recommended' => 'same-origin',
-            'validate'    => 'validateCorp',
+            'validate' => 'validateCorp',
         ],
         'Cross-Origin-Embedder-Policy' => [
-            'required'    => false,
-            'severity'    => 'low',
+            'required' => false,
+            'severity' => 'low',
             'recommended' => 'require-corp',
-            'validate'    => 'validateCoep',
+            'validate' => 'validateCoep',
         ],
     ];
 
@@ -144,7 +144,7 @@ class TestSecurityHeaders extends Command
 
         // Output results
         $format = $this->option('format');
-        if ('json' === $format) {
+        if ($format === 'json') {
             $this->outputJson();
         } else {
             $this->outputTable();
@@ -200,7 +200,7 @@ class TestSecurityHeaders extends Command
             }
 
             $response = Http::withOptions([
-                'verify'  => $verifySsl,
+                'verify' => $verifySsl,
                 'timeout' => 10,
             ])->get($url);
 
@@ -228,7 +228,7 @@ class TestSecurityHeaders extends Command
 
         // Check if URL is localhost or loopback
         $parsedUrl = parse_url($url);
-        $host      = $parsedUrl['host'] ?? '';
+        $host = $parsedUrl['host'] ?? '';
 
         $localHosts = ['localhost', '127.0.0.1', '::1', '0.0.0.0'];
 
@@ -245,32 +245,32 @@ class TestSecurityHeaders extends Command
      */
     protected function validateHeader(string $header, ?string $value, string $source): void
     {
-        $rules            = $this->headerRules[$header];
+        $rules = $this->headerRules[$header];
         $validationMethod = $rules['validate'];
 
         $result = [
-            'header'   => $header,
-            'value'    => $value,
-            'source'   => $source,
-            'present'  => null !== $value && '' !== $value,
+            'header' => $header,
+            'value' => $value,
+            'source' => $source,
+            'present' => $value !== null && $value !== '',
             'required' => $rules['required'],
             'severity' => $rules['severity'],
-            'status'   => 'unknown',
-            'grade'    => 'F',
-            'message'  => '',
+            'status' => 'unknown',
+            'grade' => 'F',
+            'message' => '',
         ];
 
         if (! $result['present']) {
-            $result['status']  = $rules['required'] ? 'missing' : 'optional_missing';
-            $result['grade']   = $rules['required'] ? 'F' : 'D';
+            $result['status'] = $rules['required'] ? 'missing' : 'optional_missing';
+            $result['grade'] = $rules['required'] ? 'F' : 'D';
             $result['message'] = $rules['required'] ? 'Required header missing' : 'Recommended header not configured';
         } else {
             // Run specific validation
             $validation = $this->$validationMethod($value);
-            $result     = array_merge($result, $validation);
+            $result = array_merge($result, $validation);
         }
 
-        $key                 = "{$header}_{$source}";
+        $key = "{$header}_{$source}";
         $this->results[$key] = $result;
     }
 
@@ -291,21 +291,21 @@ class TestSecurityHeaders extends Command
         if (preg_match('/max-age=(\d+)/', $value, $matches)) {
             $maxAge = (int) $matches[1];
             if ($maxAge < 31536000) { // Less than 1 year
-                $result['grade']   = 'B';
+                $result['grade'] = 'B';
                 $result['message'] = 'max-age should be at least 31536000 (1 year)';
             }
             if ($maxAge < 86400) { // Less than 1 day
-                $result['grade']   = 'C';
+                $result['grade'] = 'C';
                 $result['message'] = 'max-age is too short';
             }
         } else {
-            $result['grade']   = 'D';
+            $result['grade'] = 'D';
             $result['message'] = 'max-age directive missing';
         }
 
         // Check for includeSubDomains
         if (! str_contains(strtolower($value), 'includesubdomains')) {
-            if ('A' === $result['grade']) {
+            if ($result['grade'] === 'A') {
                 $result['grade'] = 'B';
             }
             $result['message'] = trim($result['message'].' Consider adding includeSubDomains');
@@ -332,11 +332,11 @@ class TestSecurityHeaders extends Command
 
         $value = strtoupper(trim($value));
 
-        if ('DENY' === $value) {
+        if ($value === 'DENY') {
             return ['status' => 'pass', 'grade' => 'A', 'message' => 'Blocks all framing'];
         }
 
-        if ('SAMEORIGIN' === $value) {
+        if ($value === 'SAMEORIGIN') {
             return ['status' => 'pass', 'grade' => 'A', 'message' => 'Allows same-origin framing'];
         }
 
@@ -358,7 +358,7 @@ class TestSecurityHeaders extends Command
             return ['status' => 'missing', 'grade' => 'F', 'message' => 'X-Content-Type-Options not configured'];
         }
 
-        if ('nosniff' === strtolower(trim($value))) {
+        if (strtolower(trim($value)) === 'nosniff') {
             return ['status' => 'pass', 'grade' => 'A', 'message' => 'Prevents MIME type sniffing'];
         }
 
@@ -383,7 +383,7 @@ class TestSecurityHeaders extends Command
         if (str_contains($value, "'unsafe-inline'") && ! str_contains($value, "'strict-dynamic'")) {
             $hasNonce = (bool) preg_match("/'nonce-/", $value);
             if (! $hasNonce) {
-                $issues[]        = "uses 'unsafe-inline'";
+                $issues[] = "uses 'unsafe-inline'";
                 $result['grade'] = 'C';
             }
         }
@@ -398,7 +398,7 @@ class TestSecurityHeaders extends Command
 
         // Check for wildcards
         if (preg_match('/\s\*\s|^\*\s|\s\*$/', $value)) {
-            $issues[]        = 'contains wildcard (*)';
+            $issues[] = 'contains wildcard (*)';
             $result['grade'] = 'D';
         }
 
@@ -412,7 +412,7 @@ class TestSecurityHeaders extends Command
 
         if (! empty($issues)) {
             $result['message'] = implode(', ', $issues);
-            $result['status']  = 'warn';
+            $result['status'] = 'warn';
         } else {
             $result['message'] = 'Well-configured policy';
         }
@@ -433,15 +433,15 @@ class TestSecurityHeaders extends Command
 
         $value = strtolower(trim($value));
 
-        if ('0' === $value) {
+        if ($value === '0') {
             return ['status' => 'pass', 'grade' => 'B', 'message' => 'Disabled (recommended if CSP is used)'];
         }
 
-        if ('1; mode=block' === $value) {
+        if ($value === '1; mode=block') {
             return ['status' => 'pass', 'grade' => 'A', 'message' => 'Enabled with block mode'];
         }
 
-        if ('1' === $value) {
+        if ($value === '1') {
             return ['status' => 'warn', 'grade' => 'B', 'message' => 'Consider adding mode=block'];
         }
 
@@ -473,11 +473,11 @@ class TestSecurityHeaders extends Command
             return ['status' => 'pass', 'grade' => 'A', 'message' => 'Secure referrer policy'];
         }
 
-        if ('origin' === $value || 'origin-when-cross-origin' === $value) {
+        if ($value === 'origin' || $value === 'origin-when-cross-origin') {
             return ['status' => 'warn', 'grade' => 'B', 'message' => 'Consider stricter policy'];
         }
 
-        if ('unsafe-url' === $value) {
+        if ($value === 'unsafe-url') {
             return ['status' => 'fail', 'grade' => 'D', 'message' => 'Unsafe: exposes full URL'];
         }
 
@@ -497,7 +497,7 @@ class TestSecurityHeaders extends Command
 
         // Check if it restricts sensitive features
         $sensitiveFeatures = ['camera', 'microphone', 'geolocation', 'payment'];
-        $restrictedCount   = 0;
+        $restrictedCount = 0;
 
         foreach ($sensitiveFeatures as $feature) {
             if (str_contains($value, "{$feature}=()") || str_contains($value, "{$feature}=self")) {
@@ -529,15 +529,15 @@ class TestSecurityHeaders extends Command
 
         $value = strtolower(trim($value));
 
-        if ('same-origin' === $value) {
+        if ($value === 'same-origin') {
             return ['status' => 'pass', 'grade' => 'A', 'message' => 'Maximum isolation'];
         }
 
-        if ('same-origin-allow-popups' === $value) {
+        if ($value === 'same-origin-allow-popups') {
             return ['status' => 'pass', 'grade' => 'B', 'message' => 'Allows popups from same origin'];
         }
 
-        if ('unsafe-none' === $value) {
+        if ($value === 'unsafe-none') {
             return ['status' => 'warn', 'grade' => 'D', 'message' => 'No protection'];
         }
 
@@ -557,15 +557,15 @@ class TestSecurityHeaders extends Command
 
         $value = strtolower(trim($value));
 
-        if ('same-origin' === $value) {
+        if ($value === 'same-origin') {
             return ['status' => 'pass', 'grade' => 'A', 'message' => 'Strict same-origin policy'];
         }
 
-        if ('same-site' === $value) {
+        if ($value === 'same-site') {
             return ['status' => 'pass', 'grade' => 'B', 'message' => 'Same-site policy'];
         }
 
-        if ('cross-origin' === $value) {
+        if ($value === 'cross-origin') {
             return ['status' => 'warn', 'grade' => 'C', 'message' => 'Allows cross-origin access'];
         }
 
@@ -585,15 +585,15 @@ class TestSecurityHeaders extends Command
 
         $value = strtolower(trim($value));
 
-        if ('require-corp' === $value) {
+        if ($value === 'require-corp') {
             return ['status' => 'pass', 'grade' => 'A', 'message' => 'Requires CORP for subresources'];
         }
 
-        if ('credentialless' === $value) {
+        if ($value === 'credentialless') {
             return ['status' => 'pass', 'grade' => 'B', 'message' => 'Removes credentials from cross-origin requests'];
         }
 
-        if ('unsafe-none' === $value) {
+        if ($value === 'unsafe-none') {
             return ['status' => 'warn', 'grade' => 'D', 'message' => 'No protection'];
         }
 
@@ -607,7 +607,7 @@ class TestSecurityHeaders extends Command
     {
         $this->newLine();
 
-        $rows             = [];
+        $rows = [];
         $processedHeaders = [];
 
         foreach ($this->results as $result) {
@@ -618,19 +618,19 @@ class TestSecurityHeaders extends Command
             $processedHeaders[] = $header;
 
             $statusIcon = match ($result['status']) {
-                'pass'             => '<fg=green>PASS</>',
-                'warn'             => '<fg=yellow>WARN</>',
-                'missing'          => '<fg=red>MISS</>',
+                'pass' => '<fg=green>PASS</>',
+                'warn' => '<fg=yellow>WARN</>',
+                'missing' => '<fg=red>MISS</>',
                 'optional_missing' => '<fg=gray>N/A</>',
-                default            => '<fg=gray>UNKN</>',
+                default => '<fg=gray>UNKN</>',
             };
 
             $gradeColor = match ($result['grade']) {
-                'A'     => 'green',
-                'B'     => 'cyan',
-                'C'     => 'yellow',
-                'D'     => 'red',
-                'F'     => 'red',
+                'A' => 'green',
+                'B' => 'cyan',
+                'C' => 'yellow',
+                'D' => 'red',
+                'F' => 'red',
                 default => 'gray',
             };
 
@@ -656,9 +656,9 @@ class TestSecurityHeaders extends Command
     protected function outputJson(): void
     {
         $output = [
-            'scan_date'       => now()->toIso8601String(),
-            'overall_grade'   => $this->calculateOverallGrade(),
-            'results'         => array_values($this->results),
+            'scan_date' => now()->toIso8601String(),
+            'overall_grade' => $this->calculateOverallGrade(),
+            'results' => array_values($this->results),
             'recommendations' => $this->getRecommendations(),
         ];
 
@@ -677,7 +677,7 @@ class TestSecurityHeaders extends Command
         // Find CSP from results
         $cspValue = null;
         foreach ($this->results as $result) {
-            if ('Content-Security-Policy' === $result['header'] && ! empty($result['value'])) {
+            if ($result['header'] === 'Content-Security-Policy' && ! empty($result['value'])) {
                 $cspValue = $result['value'];
                 break;
             }
@@ -691,7 +691,7 @@ class TestSecurityHeaders extends Command
 
         // Parse directives
         $directives = [];
-        $parts      = explode(';', $cspValue);
+        $parts = explode(';', $cspValue);
 
         foreach ($parts as $part) {
             $part = trim($part);
@@ -699,14 +699,14 @@ class TestSecurityHeaders extends Command
                 continue;
             }
 
-            $tokens                 = preg_split('/\s+/', $part);
-            $directive              = array_shift($tokens);
+            $tokens = preg_split('/\s+/', $part);
+            $directive = array_shift($tokens);
             $directives[$directive] = $tokens;
         }
 
         $rows = [];
         foreach ($directives as $directive => $values) {
-            $status    = $this->analyzeCspDirective($directive, $values);
+            $status = $this->analyzeCspDirective($directive, $values);
             $valuesStr = implode(' ', array_slice($values, 0, 3));
             if (count($values) > 3) {
                 $valuesStr .= ' (+'.(count($values) - 3).')';
@@ -752,7 +752,7 @@ class TestSecurityHeaders extends Command
             return '<fg=green>Strict Dynamic</>';
         }
 
-        if (1 === count($values) && "'self'" === $values[0]) {
+        if (count($values) === 1 && $values[0] === "'self'") {
             return '<fg=green>Self only</>';
         }
 
@@ -764,8 +764,8 @@ class TestSecurityHeaders extends Command
      */
     protected function calculateOverallGrade(): string
     {
-        $grades           = ['A' => 0, 'B' => 0, 'C' => 0, 'D' => 0, 'F' => 0];
-        $weights          = ['A' => 4, 'B' => 3, 'C' => 2, 'D' => 1, 'F' => 0];
+        $grades = ['A' => 0, 'B' => 0, 'C' => 0, 'D' => 0, 'F' => 0];
+        $weights = ['A' => 4, 'B' => 3, 'C' => 2, 'D' => 1, 'F' => 0];
         $requiredFailures = 0;
 
         $processedHeaders = [];
@@ -778,7 +778,7 @@ class TestSecurityHeaders extends Command
             $grade = $result['grade'];
             $grades[$grade]++;
 
-            if ($result['required'] && 'F' === $grade) {
+            if ($result['required'] && $grade === 'F') {
                 $requiredFailures++;
             }
         }
@@ -796,7 +796,7 @@ class TestSecurityHeaders extends Command
             $count += $num;
         }
 
-        if (0 === $count) {
+        if ($count === 0) {
             return 'F';
         }
 
@@ -825,7 +825,7 @@ class TestSecurityHeaders extends Command
      */
     protected function getRecommendations(): array
     {
-        $recommendations  = [];
+        $recommendations = [];
         $processedHeaders = [];
 
         foreach ($this->results as $result) {
@@ -834,11 +834,11 @@ class TestSecurityHeaders extends Command
             }
             $processedHeaders[] = $result['header'];
 
-            if ('missing' === $result['status'] && $result['required']) {
+            if ($result['status'] === 'missing' && $result['required']) {
                 $recommendations[] = "Add required header: {$result['header']}";
-            } elseif ('optional_missing' === $result['status']) {
+            } elseif ($result['status'] === 'optional_missing') {
                 $recommendations[] = "Consider adding: {$result['header']}";
-            } elseif (! empty($result['message']) && 'warn' === $result['status']) {
+            } elseif (! empty($result['message']) && $result['status'] === 'warn') {
                 $recommendations[] = "{$result['header']}: {$result['message']}";
             }
         }
@@ -854,11 +854,11 @@ class TestSecurityHeaders extends Command
         $grade = $this->calculateOverallGrade();
 
         $gradeColor = match ($grade) {
-            'A'      => 'green',
-            'B'      => 'cyan',
-            'C'      => 'yellow',
+            'A' => 'green',
+            'B' => 'cyan',
+            'C' => 'yellow',
             'D', 'F' => 'red',
-            default  => 'gray',
+            default => 'gray',
         };
 
         $this->newLine();

--- a/src/Contracts/CspPolicyInterface.php
+++ b/src/Contracts/CspPolicyInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ArtisanPackUI\Security\Contracts;
 
+use ArtisanPackUI\Security\Services\Csp\Presets\CspPresetInterface;
 use Illuminate\Http\Request;
 
 interface CspPolicyInterface
@@ -64,7 +65,7 @@ interface CspPolicyInterface
     /**
      * Get all registered presets.
      *
-     * @return array<string, \ArtisanPackUI\Security\Services\Csp\Presets\CspPresetInterface>
+     * @return array<string, CspPresetInterface>
      */
     public function getPresets(): array;
 

--- a/src/Facades/Csp.php
+++ b/src/Facades/Csp.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ArtisanPackUI\Security\Facades;
 
 use ArtisanPackUI\Security\Contracts\CspPolicyInterface;
+use ArtisanPackUI\Security\Services\Csp\CspPolicyService;
 use Illuminate\Support\Facades\Facade;
 
 /**
@@ -18,7 +19,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string renderMetaTag()
  * @method static self reset()
  *
- * @see \ArtisanPackUI\Security\Services\Csp\CspPolicyService
+ * @see CspPolicyService
  */
 class Csp extends Facade
 {

--- a/src/HTMLawed.php
+++ b/src/HTMLawed.php
@@ -49,9 +49,9 @@ function htmLawed(string $t, mixed $C = 1, mixed $S = []): string
 
     $C = is_array($C) ? $C : [];
     if (! empty($C['valid_xhtml'])) {
-        $C['elements']        = empty($C['elements']) ? '*-acronym-big-center-dir-font-isindex-s-strike-tt' : $C['elements'];
+        $C['elements'] = empty($C['elements']) ? '*-acronym-big-center-dir-font-isindex-s-strike-tt' : $C['elements'];
         $C['make_tag_strict'] = isset($C['make_tag_strict']) ? $C['make_tag_strict'] : 2;
-        $C['xml:lang']        = isset($C['xml:lang']) ? $C['xml:lang'] : 2;
+        $C['xml:lang'] = isset($C['xml:lang']) ? $C['xml:lang'] : 2;
     }
 
     // -- Configure for elements.
@@ -60,9 +60,9 @@ function htmLawed(string $t, mixed $C = 1, mixed $S = []): string
         unset($eleAr['applet'], $eleAr['audio'], $eleAr['canvas'], $eleAr['dialog'], $eleAr['embed'], $eleAr['iframe'], $eleAr['object'], $eleAr['script'], $eleAr['video']);
     }
     $x = ! empty($C['elements']) ? str_replace(["\n", "\r", "\t", ' '], '', strtolower($C['elements'])) : '*';
-    if ('-*' == $x) {
+    if ($x == '-*') {
         $eleAr = [];
-    } elseif (false === strpos($x, '*')) {
+    } elseif (strpos($x, '*') === false) {
         $eleAr = array_flip(explode(',', $x));
     } else {
         if (isset($x[1])) {
@@ -81,9 +81,9 @@ function htmLawed(string $t, mixed $C = 1, mixed $S = []): string
             }
             foreach ($m as $v) {
                 $v = str_replace('A', '-', $v);
-                if ('+' == $v[0]) {
+                if ($v[0] == '+') {
                     $eleAr[substr($v, 1)] = 1;
-                } elseif ('-' == $v[0]) {
+                } elseif ($v[0] == '-') {
                     if (strpos($v, '-', 1)) {
                         $eleAr[$v] = 1;
                     } elseif (isset($eleAr[($v = substr($v, 1))]) && ! in_array('+'.$v, $m)) {
@@ -97,11 +97,11 @@ function htmLawed(string $t, mixed $C = 1, mixed $S = []): string
 
     // -- Configure for attributes.
 
-    $x                   = ! empty($C['deny_attribute']) ? strtolower(preg_replace('"\s+-"', '/', trim($C['deny_attribute']))) : '';
-    $x                   = str_replace([' ', "\t", "\r", "\n"], '', $x);
-    $x                   =
+    $x = ! empty($C['deny_attribute']) ? strtolower(preg_replace('"\s+-"', '/', trim($C['deny_attribute']))) : '';
+    $x = str_replace([' ', "\t", "\r", "\n"], '', $x);
+    $x =
         array_flip(
-            (isset($x[0]) && '*' == $x[0])
+            (isset($x[0]) && $x[0] == '*')
                 ? preg_replace(
                     '`^[^*]`',
                     '-'.'\\0',
@@ -113,7 +113,7 @@ function htmLawed(string $t, mixed $C = 1, mixed $S = []): string
 
     // -- Configure URL handling.
 
-    $x            = (isset($C['schemes'][2]) && strpos($C['schemes'], ':')
+    $x = (isset($C['schemes'][2]) && strpos($C['schemes'], ':')
         ? strtolower($C['schemes'])
         : ('href: aim, feed, file, ftp, gopher, http, https, irc, mailto, news, nntp, sftp, ssh, tel, telnet, ws, wss'
             .(empty($C['safe'])
@@ -123,7 +123,7 @@ function htmLawed(string $t, mixed $C = 1, mixed $S = []): string
     $C['schemes'] = [];
     foreach (explode(';', trim(str_replace([' ', "\t", "\r", "\n"], '', $x), ';')) as $v) {
         if (strpos($v, ':')) {
-            [$x, $y]          = explode(':', $v, 2);
+            [$x, $y] = explode(':', $v, 2);
             $C['schemes'][$x] = array_flip(explode(',', $y));
         }
     }
@@ -143,39 +143,39 @@ function htmLawed(string $t, mixed $C = 1, mixed $S = []): string
 
     // -- Configure other parameters.
 
-    $C['and_mark']           = empty($C['and_mark']) ? 0 : 1;
-    $C['anti_link_spam']     =
+    $C['and_mark'] = empty($C['and_mark']) ? 0 : 1;
+    $C['anti_link_spam'] =
         (isset($C['anti_link_spam'])
             && is_array($C['anti_link_spam'])
-            && 2 == count($C['anti_link_spam'])
+            && count($C['anti_link_spam']) == 2
             && (empty($C['anti_link_spam'][0])
                 || hl_regex($C['anti_link_spam'][0]))
             && (empty($C['anti_link_spam'][1])
                 || hl_regex($C['anti_link_spam'][1])))
             ? $C['anti_link_spam']
             : 0;
-    $C['anti_mail_spam']     = isset($C['anti_mail_spam']) ? $C['anti_mail_spam'] : 0;
+    $C['anti_mail_spam'] = isset($C['anti_mail_spam']) ? $C['anti_mail_spam'] : 0;
     $C['any_custom_element'] = (! isset($C['any_custom_element']) || ! empty($C['any_custom_element'])) ? 1 : 0;
-    $C['balance']            = isset($C['balance']) ? (bool) $C['balance'] : 1;
-    $C['cdata']              = isset($C['cdata']) ? $C['cdata'] : (empty($C['safe']) ? 3 : 0);
-    $C['clean_ms_char']      = empty($C['clean_ms_char']) ? 0 : $C['clean_ms_char'];
-    $C['comment']            = isset($C['comment']) ? $C['comment'] : (empty($C['safe']) ? 3 : 0);
-    $C['css_expression']     = empty($C['css_expression']) ? 0 : 1;
-    $C['direct_list_nest']   = empty($C['direct_list_nest']) ? 0 : 1;
-    $C['hexdec_entity']      = isset($C['hexdec_entity']) ? $C['hexdec_entity'] : 1;
-    $C['hook']               = (! empty($C['hook']) && is_callable($C['hook'])) ? $C['hook'] : 0;
-    $C['hook_tag']           = (! empty($C['hook_tag']) && is_callable($C['hook_tag'])) ? $C['hook_tag'] : 0;
-    $C['keep_bad']           = isset($C['keep_bad']) ? $C['keep_bad'] : 6;
-    $C['lc_std_val']         = isset($C['lc_std_val']) ? (bool) $C['lc_std_val'] : 1;
-    $C['make_tag_strict']    = isset($C['make_tag_strict']) ? $C['make_tag_strict'] : 1;
-    $C['named_entity']       = isset($C['named_entity']) ? (bool) $C['named_entity'] : 1;
+    $C['balance'] = isset($C['balance']) ? (bool) $C['balance'] : 1;
+    $C['cdata'] = isset($C['cdata']) ? $C['cdata'] : (empty($C['safe']) ? 3 : 0);
+    $C['clean_ms_char'] = empty($C['clean_ms_char']) ? 0 : $C['clean_ms_char'];
+    $C['comment'] = isset($C['comment']) ? $C['comment'] : (empty($C['safe']) ? 3 : 0);
+    $C['css_expression'] = empty($C['css_expression']) ? 0 : 1;
+    $C['direct_list_nest'] = empty($C['direct_list_nest']) ? 0 : 1;
+    $C['hexdec_entity'] = isset($C['hexdec_entity']) ? $C['hexdec_entity'] : 1;
+    $C['hook'] = (! empty($C['hook']) && is_callable($C['hook'])) ? $C['hook'] : 0;
+    $C['hook_tag'] = (! empty($C['hook_tag']) && is_callable($C['hook_tag'])) ? $C['hook_tag'] : 0;
+    $C['keep_bad'] = isset($C['keep_bad']) ? $C['keep_bad'] : 6;
+    $C['lc_std_val'] = isset($C['lc_std_val']) ? (bool) $C['lc_std_val'] : 1;
+    $C['make_tag_strict'] = isset($C['make_tag_strict']) ? $C['make_tag_strict'] : 1;
+    $C['named_entity'] = isset($C['named_entity']) ? (bool) $C['named_entity'] : 1;
     $C['no_deprecated_attr'] = isset($C['no_deprecated_attr']) ? $C['no_deprecated_attr'] : 1;
-    $C['parent']             = isset($C['parent'][0]) ? strtolower($C['parent']) : 'body';
-    $C['show_setting']       = ! empty($C['show_setting']) ? $C['show_setting'] : 0;
-    $C['style_pass']         = empty($C['style_pass']) ? 0 : 1;
-    $C['tidy']               = empty($C['tidy']) ? 0 : $C['tidy'];
-    $C['unique_ids']         = isset($C['unique_ids']) && (! preg_match('`\W`', $C['unique_ids'])) ? $C['unique_ids'] : 1;
-    $C['xml:lang']           = isset($C['xml:lang']) ? $C['xml:lang'] : 0;
+    $C['parent'] = isset($C['parent'][0]) ? strtolower($C['parent']) : 'body';
+    $C['show_setting'] = ! empty($C['show_setting']) ? $C['show_setting'] : 0;
+    $C['style_pass'] = empty($C['style_pass']) ? 0 : 1;
+    $C['tidy'] = empty($C['tidy']) ? 0 : $C['tidy'];
+    $C['unique_ids'] = isset($C['unique_ids']) && (! preg_match('`\W`', $C['unique_ids'])) ? $C['unique_ids'] : 1;
+    $C['xml:lang'] = isset($C['xml:lang']) ? $C['xml:lang'] : 0;
 
     if (isset($GLOBALS['C'])) {
         $oldC = $GLOBALS['C'];
@@ -196,7 +196,7 @@ function htmLawed(string $t, mixed $C = 1, mixed $S = []): string
     if ($C['clean_ms_char']) { // Convert MS Windows CP-1252
         $x = ["\x7f" => '', "\x80" => '&#8364;', "\x81" => '', "\x83" => '&#402;', "\x85" => '&#8230;', "\x86" => '&#8224;', "\x87" => '&#8225;', "\x88" => '&#710;', "\x89" => '&#8240;', "\x8a" => '&#352;', "\x8b" => '&#8249;', "\x8c" => '&#338;', "\x8d" => '', "\x8e" => '&#381;', "\x8f" => '', "\x90" => '', "\x95" => '&#8226;', "\x96" => '&#8211;', "\x97" => '&#8212;', "\x98" => '&#732;', "\x99" => '&#8482;', "\x9a" => '&#353;', "\x9b" => '&#8250;', "\x9c" => '&#339;', "\x9d" => '', "\x9e" => '&#382;', "\x9f" => '&#376;'];
         $x = $x
-            + (1 == $C['clean_ms_char']
+            + ($C['clean_ms_char'] == 1
                 ? ["\x82" => '&#8218;', "\x84" => '&#8222;', "\x91" => '&#8216;', "\x92" => '&#8217;', "\x93" => '&#8220;', "\x94" => '&#8221;']
                 : ["\x82" => '\'', "\x84" => '"', "\x91" => '\'', "\x92" => '\'', "\x93" => '"', "\x94" => '"']);
         $t = strtr($t, $x);
@@ -224,7 +224,7 @@ function htmLawed(string $t, mixed $C = 1, mixed $S = []): string
 
     $t = preg_replace_callback('`<(?:(?:\s|$)|(?:[^>]*(?:>|$)))|>`m', 'ArtisanPackUI\Security\HTMLawed\hl_tag', $t);
     $t = $C['balance'] ? hl_balance($t, $C['keep_bad'], $C['parent']) : $t;
-    $t = (($C['cdata'] || $C['comment']) && false !== strpos($t, "\x01"))
+    $t = (($C['cdata'] || $C['comment']) && strpos($t, "\x01") !== false)
         ? str_replace(["\x01", "\x02", "\x03", "\x04", "\x05"], ['', '', '&', '<', '>'], $t)
         : $t;
     $t = $C['tidy'] ? hl_tidy($t, $C['tidy'], $C['parent']) : $t;
@@ -252,24 +252,23 @@ function htmLawed(string $t, mixed $C = 1, mixed $S = []): string
  * @param  string  $value  Attribute value.
  * @param  array  $ruleAr  Array of rules derived from $spec.
  * @param  string  $ele  Element.
- *
  * @return mixed 0 if invalid $value,
  *               or string with validated or default value.
  */
 function hl_attributeValue(string $attr, string $value, array $ruleAr, string $ele): mixed
 {
     static $spacedValsAttrAr = ['accesskey', 'class', 'itemtype', 'rel']; // Some attributes have multiple values
-    $valSep                  =
-        (in_array($attr, $spacedValsAttrAr) || ('archive' == $attr && 'object' == $ele))
+    $valSep =
+        (in_array($attr, $spacedValsAttrAr) || ($attr == 'archive' && $ele == 'object'))
             ? ' '
-            : (('sizes' == $attr || 'srcset' == $attr || ('archive' == $attr && 'applet' == $ele))
+            : (($attr == 'sizes' || $attr == 'srcset' || ($attr == 'archive' && $ele == 'applet'))
             ? ','
             : '');
-    $out    = [];
-    $valAr  = ! empty($valSep) ? explode($valSep, $value) : [$value];
+    $out = [];
+    $valAr = ! empty($valSep) ? explode($valSep, $value) : [$value];
     foreach ($valAr as $v) {
-        $ok        = 1;
-        $v         = trim($v);
+        $ok = 1;
+        $v = trim($v);
         $lengthVal = strlen($v);
         foreach ($ruleAr as $ruleType => $ruleVal) {
             if (! $lengthVal) {
@@ -327,7 +326,7 @@ function hl_attributeValue(string $attr, string $value, array $ruleAr, string $e
             $out[] = $v;
         }
     }
-    $out = implode(',' == $valSep ? ', ' : ' ', $out);
+    $out = implode($valSep == ',' ? ', ' : ' ', $out);
 
     return isset($out[0]) ? $out : (isset($ruleAr['default']) ? $ruleAr['default'] : 0);
 }
@@ -349,24 +348,24 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
 
     // -- Block, inline, etc.
 
-    $blockEleAr  = ['a' => 1, 'address' => 1, 'article' => 1, 'aside' => 1, 'blockquote' => 1, 'center' => 1, 'del' => 1, 'details' => 1, 'dialog' => 1, 'dir' => 1, 'dl' => 1, 'div' => 1, 'fieldset' => 1, 'figure' => 1, 'footer' => 1, 'form' => 1, 'ins' => 1, 'h1' => 1, 'h2' => 1, 'h3' => 1, 'h4' => 1, 'h5' => 1, 'h6' => 1, 'header' => 1, 'hr' => 1, 'isindex' => 1, 'main' => 1, 'menu' => 1, 'nav' => 1, 'noscript' => 1, 'ol' => 1, 'p' => 1, 'pre' => 1, 'section' => 1, 'slot' => 1, 'style' => 1, 'table' => 1, 'template' => 1, 'ul' => 1];
+    $blockEleAr = ['a' => 1, 'address' => 1, 'article' => 1, 'aside' => 1, 'blockquote' => 1, 'center' => 1, 'del' => 1, 'details' => 1, 'dialog' => 1, 'dir' => 1, 'dl' => 1, 'div' => 1, 'fieldset' => 1, 'figure' => 1, 'footer' => 1, 'form' => 1, 'ins' => 1, 'h1' => 1, 'h2' => 1, 'h3' => 1, 'h4' => 1, 'h5' => 1, 'h6' => 1, 'header' => 1, 'hr' => 1, 'isindex' => 1, 'main' => 1, 'menu' => 1, 'nav' => 1, 'noscript' => 1, 'ol' => 1, 'p' => 1, 'pre' => 1, 'section' => 1, 'slot' => 1, 'style' => 1, 'table' => 1, 'template' => 1, 'ul' => 1];
     $inlineEleAr = ['#pcdata' => 1, 'a' => 1, 'abbr' => 1, 'acronym' => 1, 'applet' => 1, 'audio' => 1, 'b' => 1, 'bdi' => 1, 'bdo' => 1, 'big' => 1, 'br' => 1, 'button' => 1, 'canvas' => 1, 'cite' => 1, 'code' => 1, 'command' => 1, 'data' => 1, 'datalist' => 1, 'del' => 1, 'dfn' => 1, 'em' => 1, 'embed' => 1, 'figcaption' => 1, 'font' => 1, 'i' => 1, 'iframe' => 1, 'img' => 1, 'input' => 1, 'ins' => 1, 'kbd' => 1, 'label' => 1, 'link' => 1, 'map' => 1, 'mark' => 1, 'meta' => 1, 'meter' => 1, 'object' => 1, 'output' => 1, 'picture' => 1, 'progress' => 1, 'q' => 1, 'ruby' => 1, 's' => 1, 'samp' => 1, 'select' => 1, 'script' => 1, 'small' => 1, 'span' => 1, 'strike' => 1, 'strong' => 1, 'sub' => 1, 'summary' => 1, 'sup' => 1, 'textarea' => 1, 'time' => 1, 'tt' => 1, 'u' => 1, 'var' => 1, 'video' => 1, 'wbr' => 1];
-    $otherEleAr  = ['area' => 1, 'caption' => 1, 'col' => 1, 'colgroup' => 1, 'command' => 1, 'dd' => 1, 'dt' => 1, 'hgroup' => 1, 'keygen' => 1, 'legend' => 1, 'li' => 1, 'optgroup' => 1, 'option' => 1, 'param' => 1, 'rb' => 1, 'rbc' => 1, 'rp' => 1, 'rt' => 1, 'rtc' => 1, 'script' => 1, 'source' => 1, 'tbody' => 1, 'td' => 1, 'tfoot' => 1, 'thead' => 1, 'th' => 1, 'tr' => 1, 'track' => 1];
-    $flowEleAr   = $blockEleAr + $inlineEleAr;
+    $otherEleAr = ['area' => 1, 'caption' => 1, 'col' => 1, 'colgroup' => 1, 'command' => 1, 'dd' => 1, 'dt' => 1, 'hgroup' => 1, 'keygen' => 1, 'legend' => 1, 'li' => 1, 'optgroup' => 1, 'option' => 1, 'param' => 1, 'rb' => 1, 'rbc' => 1, 'rp' => 1, 'rt' => 1, 'rtc' => 1, 'script' => 1, 'source' => 1, 'tbody' => 1, 'td' => 1, 'tfoot' => 1, 'thead' => 1, 'th' => 1, 'tr' => 1, 'track' => 1];
+    $flowEleAr = $blockEleAr + $inlineEleAr;
 
     // -- Type of child allowed.
 
-    $blockKidEleAr  = ['blockquote' => 1, 'form' => 1, 'map' => 1, 'noscript' => 1];
-    $flowKidEleAr   = ['a' => 1, 'article' => 1, 'aside' => 1, 'audio' => 1, 'button' => 1, 'canvas' => 1, 'del' => 1, 'details' => 1, 'dialog' => 1, 'div' => 1, 'dd' => 1, 'fieldset' => 1, 'figure' => 1, 'footer' => 1, 'header' => 1, 'iframe' => 1, 'ins' => 1, 'li' => 1, 'main' => 1, 'menu' => 1, 'nav' => 1, 'noscript' => 1, 'object' => 1, 'section' => 1, 'slot' => 1, 'style' => 1, 'td' => 1, 'template' => 1, 'th' => 1, 'video' => 1]; // Later context-wise dynamic move of ins & del to $inlineKidEleAr
+    $blockKidEleAr = ['blockquote' => 1, 'form' => 1, 'map' => 1, 'noscript' => 1];
+    $flowKidEleAr = ['a' => 1, 'article' => 1, 'aside' => 1, 'audio' => 1, 'button' => 1, 'canvas' => 1, 'del' => 1, 'details' => 1, 'dialog' => 1, 'div' => 1, 'dd' => 1, 'fieldset' => 1, 'figure' => 1, 'footer' => 1, 'header' => 1, 'iframe' => 1, 'ins' => 1, 'li' => 1, 'main' => 1, 'menu' => 1, 'nav' => 1, 'noscript' => 1, 'object' => 1, 'section' => 1, 'slot' => 1, 'style' => 1, 'td' => 1, 'template' => 1, 'th' => 1, 'video' => 1]; // Later context-wise dynamic move of ins & del to $inlineKidEleAr
     $inlineKidEleAr = ['abbr' => 1, 'acronym' => 1, 'address' => 1, 'b' => 1, 'bdi' => 1, 'bdo' => 1, 'big' => 1, 'caption' => 1, 'cite' => 1, 'code' => 1, 'data' => 1, 'datalist' => 1, 'dfn' => 1, 'dt' => 1, 'em' => 1, 'figcaption' => 1, 'font' => 1, 'h1' => 1, 'h2' => 1, 'h3' => 1, 'h4' => 1, 'h5' => 1, 'h6' => 1, 'hgroup' => 1, 'i' => 1, 'kbd' => 1, 'label' => 1, 'legend' => 1, 'mark' => 1, 'meter' => 1, 'output' => 1, 'p' => 1, 'picture' => 1, 'pre' => 1, 'progress' => 1, 'q' => 1, 'rb' => 1, 'rt' => 1, 'ruby' => 1, 's' => 1, 'samp' => 1, 'small' => 1, 'span' => 1, 'strike' => 1, 'strong' => 1, 'sub' => 1, 'summary' => 1, 'sup' => 1, 'time' => 1, 'tt' => 1, 'u' => 1, 'var' => 1];
-    $noKidEleAr     = ['area' => 1, 'br' => 1, 'col' => 1, 'command' => 1, 'embed' => 1, 'hr' => 1, 'img' => 1, 'input' => 1, 'isindex' => 1, 'keygen' => 1, 'link' => 1, 'meta' => 1, 'param' => 1, 'source' => 1, 'track' => 1, 'wbr' => 1];
+    $noKidEleAr = ['area' => 1, 'br' => 1, 'col' => 1, 'command' => 1, 'embed' => 1, 'hr' => 1, 'img' => 1, 'input' => 1, 'isindex' => 1, 'keygen' => 1, 'link' => 1, 'meta' => 1, 'param' => 1, 'source' => 1, 'track' => 1, 'wbr' => 1];
 
     // Special parent-child relations.
 
     $invalidMomKidAr = ['a' => ['a' => 1, 'address' => 1, 'button' => 1, 'details' => 1, 'embed' => 1, 'iframe' => 1, 'keygen' => 1, 'label' => 1, 'select' => 1, 'textarea' => 1], 'address' => ['address' => 1, 'article' => 1, 'aside' => 1, 'footer' => 1, 'h1' => 1, 'h2' => 1, 'h3' => 1, 'h4' => 1, 'h5' => 1, 'h6' => 1, 'header' => 1, 'hgroup' => 1, 'keygen' => 1, 'nav' => 1, 'section' => 1], 'audio' => ['audio' => 1, 'video' => 1], 'button' => ['a' => 1, 'address' => 1, 'button' => 1, 'details' => 1, 'embed' => 1, 'iframe' => 1, 'keygen' => 1, 'label' => 1, 'select' => 1, 'textarea' => 1], 'dfn' => ['dfn' => 1], 'fieldset' => ['fieldset' => 1], 'footer' => ['footer' => 1, 'header' => 1], 'form' => ['form' => 1], 'header' => ['footer' => 1, 'header' => 1], 'label' => ['label' => 1], 'main' => ['main' => 1], 'meter' => ['meter' => 1], 'noscript' => ['script' => 1], 'progress' => ['progress' => 1], 'rb' => ['ruby' => 1], 'rt' => ['ruby' => 1], 'ruby' => ['ruby' => 1], 'time' => ['time' => 1], 'video' => ['audio' => 1, 'video' => 1]];
     $invalidKidEleAr = ['a' => 1, 'address' => 1, 'article' => 1, 'aside' => 1, 'audio' => 1, 'button' => 1, 'details' => 1, 'dfn' => 1, 'embed' => 1, 'fieldset' => 1, 'footer' => 1, 'form' => 1, 'h1' => 1, 'h2' => 1, 'h3' => 1, 'h4' => 1, 'h5' => 1, 'h6' => 1, 'header' => 1, 'hgroup' => 1, 'iframe' => 1, 'keygen' => 1, 'label' => 1, 'main' => 1, 'meter' => 1, 'nav' => 1, 'progress' => 1, 'ruby' => 1, 'script' => 1, 'section' => 1, 'select' => 1, 'textarea' => 1, 'time' => 1, 'video' => 1]; // $invalidMomKidAr values
     $invalidMomEleAr = array_keys($invalidMomKidAr);
-    $validMomKidAr   = ['colgroup' => ['col' => 1, 'template' => 1], 'datalist' => ['option' => 1, 'script' => 1], 'dir' => ['li' => 1], 'dl' => ['dd' => 1, 'div' => 1, 'dt' => 1], 'hgroup' => ['h1' => 1, 'h2' => 1, 'h3' => 1, 'h4' => 1, 'h5' => 1, 'h6' => 1], 'menu' => ['li' => 1, 'script' => 1, 'template' => 1], 'ol' => ['li' => 1, 'script' => 1, 'template' => 1], 'optgroup' => ['option' => 1, 'script' => 1, 'template' => 1], 'option' => ['#pcdata' => 1], 'picture' => ['img' => 1, 'script' => 1, 'source' => 1, 'template' => 1], 'rbc' => ['rb' => 1], 'rp' => ['#pcdata' => 1], 'rtc' => ['rp' => 1, 'rt' => 1], 'select' => ['optgroup' => 1, 'option' => 1], 'script' => ['#pcdata' => 1], 'table' => ['caption' => 1, 'col' => 1, 'colgroup' => 1, 'script' => 1, 'tbody' => 1, 'tfoot' => 1, 'thead' => 1, 'tr' => 1, 'template' => 1], 'tbody' => ['script' => 1, 'template' => 1, 'tr' => 1], 'tfoot' => ['tr' => 1], 'textarea' => ['#pcdata' => 1], 'thead' => ['script' => 1, 'template' => 1, 'tr' => 1], 'tr' => ['script' => 1, 'td' => 1, 'template' => 1, 'th' => 1], 'ul' => ['li' => 1, 'script' => 1, 'template' => 1]]; // Immediate parent-child relation
+    $validMomKidAr = ['colgroup' => ['col' => 1, 'template' => 1], 'datalist' => ['option' => 1, 'script' => 1], 'dir' => ['li' => 1], 'dl' => ['dd' => 1, 'div' => 1, 'dt' => 1], 'hgroup' => ['h1' => 1, 'h2' => 1, 'h3' => 1, 'h4' => 1, 'h5' => 1, 'h6' => 1], 'menu' => ['li' => 1, 'script' => 1, 'template' => 1], 'ol' => ['li' => 1, 'script' => 1, 'template' => 1], 'optgroup' => ['option' => 1, 'script' => 1, 'template' => 1], 'option' => ['#pcdata' => 1], 'picture' => ['img' => 1, 'script' => 1, 'source' => 1, 'template' => 1], 'rbc' => ['rb' => 1], 'rp' => ['#pcdata' => 1], 'rtc' => ['rp' => 1, 'rt' => 1], 'select' => ['optgroup' => 1, 'option' => 1], 'script' => ['#pcdata' => 1], 'table' => ['caption' => 1, 'col' => 1, 'colgroup' => 1, 'script' => 1, 'tbody' => 1, 'tfoot' => 1, 'thead' => 1, 'tr' => 1, 'template' => 1], 'tbody' => ['script' => 1, 'template' => 1, 'tr' => 1], 'tfoot' => ['tr' => 1], 'textarea' => ['#pcdata' => 1], 'thead' => ['script' => 1, 'template' => 1, 'tr' => 1], 'tr' => ['script' => 1, 'td' => 1, 'template' => 1, 'th' => 1], 'ul' => ['li' => 1, 'script' => 1, 'template' => 1]]; // Immediate parent-child relation
     if ($GLOBALS['C']['direct_list_nest']) {
         $validMomKidAr['ol'] = $validMomKidAr['ul'] = $validMomKidAr['menu'] += ['menu' => 1, 'ol' => 1, 'ul' => 1];
     }
@@ -374,7 +373,7 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
 
     // Valid elements for top-level parent.
 
-    $mom = ((isset($flowEleAr[$parentEle]) && '#pcdata' != $parentEle)
+    $mom = ((isset($flowEleAr[$parentEle]) && $parentEle != '#pcdata')
         || isset($otherEleAr[$parentEle]))
         ? $parentEle
         : 'div';
@@ -384,7 +383,7 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
     if (isset($validMomKidAr[$mom])) {
         $validInMomEleAr = $validMomKidAr[$mom];
     } elseif (isset($inlineKidEleAr[$mom])) {
-        $validInMomEleAr       = $inlineEleAr;
+        $validInMomEleAr = $inlineEleAr;
         $inlineKidEleAr['del'] = 1;
         $inlineKidEleAr['ins'] = 1;
     } elseif (isset($flowKidEleAr[$mom])) {
@@ -406,7 +405,7 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
 
     // Loop over elements.
 
-    $t              = explode('<', $t);
+    $t = explode('<', $t);
     $validKidsOfMom = $openEleQueue = []; // Queue of opened elements
     ob_start();
     for ($i = -1, $eleCount = count($t); ++$i < $eleCount;) {
@@ -414,12 +413,12 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
         // Check element validity as child. Same code as section: Finishing (below).
 
         if ($queueLength = count($openEleQueue)) {
-            $eleNow         = array_pop($openEleQueue);
+            $eleNow = array_pop($openEleQueue);
             $openEleQueue[] = $eleNow;
             if (isset($validMomKidAr[$eleNow])) {
                 $validKidsOfMom = $validMomKidAr[$eleNow];
             } elseif (isset($inlineKidEleAr[$eleNow])) {
-                $validKidsOfMom        = $inlineEleAr;
+                $validKidsOfMom = $inlineEleAr;
                 $inlineKidEleAr['del'] = 1;
                 $inlineKidEleAr['ins'] = 1;
             } elseif (isset($flowKidEleAr[$eleNow])) {
@@ -444,10 +443,10 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
         }
         if (
             isset($ele)
-            && (1 == $act
+            && ($act == 1
                 || (isset($validKidsOfMom['#pcdata'])
-                    && (3 == $act
-                        || 5 == $act)))
+                    && ($act == 3
+                        || $act == 5)))
         ) {
             echo '&lt;', $slash, $ele, $attrs, '&gt;';
         }
@@ -463,7 +462,7 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
                 foreach (
                     preg_split(
                         '`(\x01\x02[^\x01\x02]+\x02\x01)`', $content, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY) as $m) {
-                    echo "\x01\x02" == substr($m, 0, 2)
+                    echo substr($m, 0, 2) == "\x01\x02"
                         ? $m
                         : ($act > 4
                         ? preg_replace('`\S`', '', $m)
@@ -481,10 +480,10 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
 
             continue;
         }
-        $slash                                 = null; // Closing tag's slash
-        $ele                                   = null; // Name
-        $attrs                                 = null; // Attribute string
-        $content                               = null; // Content
+        $slash = null; // Closing tag's slash
+        $ele = null; // Name
+        $attrs = null; // Attribute string
+        $content = null; // Content
         [$all, $slash, $ele, $attrs, $content] = $m;
 
         // Handle closing tag.
@@ -572,11 +571,11 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
 
             continue;
         }
-        $closedTags    = ''; // Nesting, so close open elements as needed
+        $closedTags = ''; // Nesting, so close open elements as needed
         $openEleQueue2 = [];
         for ($k = -1, $kc = count($openEleQueue); ++$k < $kc;) {
             $closableEle = $openEleQueue[$k];
-            $validKids2  = [];
+            $validKids2 = [];
             if (isset($validMomKidAr[$closableEle])) {
                 $openEleQueue2[] = $closableEle;
 
@@ -615,12 +614,12 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
     // Finishing. Same code as: 'Check element validity as child'.
 
     if ($queueLength = count($openEleQueue)) {
-        $eleNow         = array_pop($openEleQueue);
+        $eleNow = array_pop($openEleQueue);
         $openEleQueue[] = $eleNow;
         if (isset($validMomKidAr[$eleNow])) {
             $validKidsOfMom = $validMomKidAr[$eleNow];
         } elseif (isset($inlineKidEleAr[$eleNow])) {
-            $validKidsOfMom        = $inlineEleAr;
+            $validKidsOfMom = $inlineEleAr;
             $inlineKidEleAr['del'] = 1;
             $inlineKidEleAr['ins'] = 1;
         } elseif (isset($flowKidEleAr[$eleNow])) {
@@ -645,10 +644,10 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
     }
     if (
         isset($ele)
-        && (1 == $act
+        && ($act == 1
             || (isset($validKidsOfMom['#pcdata'])
-                && (3 == $act
-                    || 5 == $act)))
+                && ($act == 3
+                    || $act == 5)))
     ) {
         echo '&lt;', $slash, $ele, $attrs, '&gt;';
     }
@@ -665,7 +664,7 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
             foreach (
                 preg_split(
                     '`(\x01\x02[^\x01\x02]+\x02\x01)`', $content, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY) as $m) {
-                echo "\x01\x02" == substr($m, 0, 2)
+                echo substr($m, 0, 2) == "\x01\x02"
                     ? $m
                     : ($act > 4
                     ? preg_replace('`\S`', '', $m)
@@ -691,33 +690,32 @@ function hl_balance(string $t, int $act = 1, string $parentEle = 'div'): string
  * Filter/sanitize as per $config and disguise special characters.
  *
  * @param  array  $t  Array result of preg_replace, with potential comment/CDATA.
- *
  * @return string Sanitized comment/CDATA with hidden special characters.
  */
 function hl_commentCdata(array $t): string
 {
     $t = $t[0];
     global $C;
-    if (! ($rule = $C[$type = '-' == $t[3] ? 'comment' : 'cdata'])) {
+    if (! ($rule = $C[$type = $t[3] == '-' ? 'comment' : 'cdata'])) {
         return $t;
     }
-    if (1 == $rule) {
+    if ($rule == 1) {
         return '';
     }
-    if ('comment' == $type) {
-        if (' ' != substr(($t = preg_replace('`--+`', '-', substr($t, 4, -3))), -1)) {
-            $t .= 4 == $rule ? '' : ' ';
+    if ($type == 'comment') {
+        if (substr(($t = preg_replace('`--+`', '-', substr($t, 4, -3))), -1) != ' ') {
+            $t .= $rule == 4 ? '' : ' ';
         }
     } else {
         $t = substr($t, 1, -1);
     }
-    $t = 2 == $rule ? str_replace(['&', '<', '>'], ['&amp;', '&lt;', '&gt;'], $t) : $t;
+    $t = $rule == 2 ? str_replace(['&', '<', '>'], ['&amp;', '&lt;', '&gt;'], $t) : $t;
 
     return
         str_replace(
             ['&', '<', '>'],
             ["\x03", "\x04", "\x05"],
-            ('comment' == $type ? "\x01\x02\x04!--$t--\x05\x02\x01" : "\x01\x01\x04$t\x05\x01\x01"));
+            ($type == 'comment' ? "\x01\x02\x04!--$t--\x05\x02\x01" : "\x01\x01\x04$t\x05\x01\x01"));
 }
 
 /**
@@ -727,38 +725,37 @@ function hl_commentCdata(array $t): string
  * @param  string  $ele  Deprecated element.
  * @param  string  $attrStr  Attribute string of element.
  * @param  int  $act  No transformation if 2.
- *
  * @return mixed New attribute string (may be empty) or 0.
  */
 function hl_deprecatedElement(string &$ele, string &$attrStr, int $act = 1): mixed
 {
-    if ('big' == $ele) {
+    if ($ele == 'big') {
         $ele = 'span';
 
         return 'font-size: larger;';
     }
-    if ('s' == $ele || 'strike' == $ele) {
+    if ($ele == 's' || $ele == 'strike') {
         $ele = 'span';
 
         return 'text-decoration: line-through;';
     }
-    if ('tt' == $ele) {
+    if ($ele == 'tt') {
         $ele = 'code';
 
         return '';
     }
-    if ('center' == $ele) {
+    if ($ele == 'center') {
         $ele = 'div';
 
         return 'text-align: center;';
     }
     static $fontSizeAr = ['0' => 'xx-small', '1' => 'xx-small', '2' => 'small', '3' => 'medium', '4' => 'large', '5' => 'x-large', '6' => 'xx-large', '7' => '300%', '-1' => 'smaller', '-2' => '60%', '+1' => 'larger', '+2' => '150%', '+3' => '200%', '+4' => '300%'];
-    if ('font' == $ele) {
+    if ($ele == 'font') {
         $attrStrNew = '';
         while (preg_match('`(^|\s)(color|size)\s*=\s*(\'|")?(.+?)(\\3|\s|$)`i', $attrStr, $m)) {
-            $attrStr    = str_replace($m[0], ' ', $attrStr);
+            $attrStr = str_replace($m[0], ' ', $attrStr);
             $attrStrNew .=
-                'color' == strtolower($m[2])
+                strtolower($m[2]) == 'color'
                     ? ' color: '.str_replace(['"', ';', ':'], '\'', trim($m[4])).';'
                     : (isset($fontSizeAr[($m = trim($m[4]))])
                     ? ' font-size: '.$fontSizeAr[$m].';'
@@ -768,24 +765,24 @@ function hl_deprecatedElement(string &$ele, string &$attrStr, int $act = 1): mix
             preg_match('`(^|\s)face\s*=\s*(\'|")?([^=]+?)\\2`i', $attrStr, $m)
             || preg_match('`(^|\s)face\s*=(\s*)(\S+)`i', $attrStr, $m)
         ) {
-            $attrStr    = str_replace($m[0], ' ', $attrStr);
+            $attrStr = str_replace($m[0], ' ', $attrStr);
             $attrStrNew .= ' font-family: '.str_replace(['"', ';', ':'], '\'', trim($m[3])).';';
         }
         $ele = 'span';
 
         return ltrim(str_replace('<', '', $attrStrNew));
     }
-    if ('acronym' == $ele) {
+    if ($ele == 'acronym') {
         $ele = 'abbr';
 
         return '';
     }
-    if ('dir' == $ele) {
+    if ($ele == 'dir') {
         $ele = 'ul';
 
         return '';
     }
-    if (2 == $act) {
+    if ($act == 2) {
         $ele = 0;
 
         return 0;
@@ -800,17 +797,16 @@ function hl_deprecatedElement(string &$ele, string &$attrStr, int $act = 1): mix
  * As needed, convert to named/hexadecimal form, or neutralize '&' as '&amp;'.
  *
  * @param  array  $t  Array result of preg_replace, with potential entity.
- *
  * @return string Neutralized or converted entity.
  */
 function hl_entity(array $t): string
 {
     global $C;
-    $t                      = $t[1];
-    static $reservedEntAr   = ['amp' => 1, 'AMP' => 1, 'gt' => 1, 'GT' => 1, 'lt' => 1, 'LT' => 1, 'quot' => 1, 'QUOT' => 1];
+    $t = $t[1];
+    static $reservedEntAr = ['amp' => 1, 'AMP' => 1, 'gt' => 1, 'GT' => 1, 'lt' => 1, 'LT' => 1, 'quot' => 1, 'QUOT' => 1];
     static $commonEntNameAr = ['Aacute' => '193', 'aacute' => '225', 'Acirc' => '194', 'acirc' => '226', 'acute' => '180', 'AElig' => '198', 'aelig' => '230', 'Agrave' => '192', 'agrave' => '224', 'alefsym' => '8501', 'Alpha' => '913', 'alpha' => '945', 'and' => '8743', 'ang' => '8736', 'apos' => '39', 'Aring' => '197', 'aring' => '229', 'asymp' => '8776', 'Atilde' => '195', 'atilde' => '227', 'Auml' => '196', 'auml' => '228', 'bdquo' => '8222', 'Beta' => '914', 'beta' => '946', 'brvbar' => '166', 'bull' => '8226', 'cap' => '8745', 'Ccedil' => '199', 'ccedil' => '231', 'cedil' => '184', 'cent' => '162', 'Chi' => '935', 'chi' => '967', 'circ' => '710', 'clubs' => '9827', 'cong' => '8773', 'copy' => '169', 'crarr' => '8629', 'cup' => '8746', 'curren' => '164', 'dagger' => '8224', 'Dagger' => '8225', 'darr' => '8595', 'dArr' => '8659', 'deg' => '176', 'Delta' => '916', 'delta' => '948', 'diams' => '9830', 'divide' => '247', 'Eacute' => '201', 'eacute' => '233', 'Ecirc' => '202', 'ecirc' => '234', 'Egrave' => '200', 'egrave' => '232', 'empty' => '8709', 'emsp' => '8195', 'ensp' => '8194', 'Epsilon' => '917', 'epsilon' => '949', 'equiv' => '8801', 'Eta' => '919', 'eta' => '951', 'ETH' => '208', 'eth' => '240', 'Euml' => '203', 'euml' => '235', 'euro' => '8364', 'exist' => '8707', 'fnof' => '402', 'forall' => '8704', 'frac12' => '189', 'frac14' => '188', 'frac34' => '190', 'frasl' => '8260', 'Gamma' => '915', 'gamma' => '947', 'ge' => '8805', 'harr' => '8596', 'hArr' => '8660', 'hearts' => '9829', 'hellip' => '8230', 'Iacute' => '205', 'iacute' => '237', 'Icirc' => '206', 'icirc' => '238', 'iexcl' => '161', 'Igrave' => '204', 'igrave' => '236', 'image' => '8465', 'infin' => '8734', 'int' => '8747', 'Iota' => '921', 'iota' => '953', 'iquest' => '191', 'isin' => '8712', 'Iuml' => '207', 'iuml' => '239', 'Kappa' => '922', 'kappa' => '954', 'Lambda' => '923', 'lambda' => '955', 'laquo' => '171', 'larr' => '8592', 'lArr' => '8656', 'lceil' => '8968', 'ldquo' => '8220', 'le' => '8804', 'lfloor' => '8970', 'lowast' => '8727', 'loz' => '9674', 'lrm' => '8206', 'lsaquo' => '8249', 'lsquo' => '8216', 'macr' => '175', 'mdash' => '8212', 'micro' => '181', 'middot' => '183', 'minus' => '8722', 'Mu' => '924', 'mu' => '956', 'nabla' => '8711', 'nbsp' => '160', 'ndash' => '8211', 'ne' => '8800', 'ni' => '8715', 'not' => '172', 'notin' => '8713', 'nsub' => '8836', 'Ntilde' => '209', 'ntilde' => '241', 'Nu' => '925', 'nu' => '957', 'Oacute' => '211', 'oacute' => '243', 'Ocirc' => '212', 'ocirc' => '244', 'OElig' => '338', 'oelig' => '339', 'Ograve' => '210', 'ograve' => '242', 'oline' => '8254', 'Omega' => '937', 'omega' => '969', 'Omicron' => '927', 'omicron' => '959', 'oplus' => '8853', 'or' => '8744', 'ordf' => '170', 'ordm' => '186', 'Oslash' => '216', 'oslash' => '248', 'Otilde' => '213', 'otilde' => '245', 'otimes' => '8855', 'Ouml' => '214', 'ouml' => '246', 'para' => '182', 'part' => '8706', 'permil' => '8240', 'perp' => '8869', 'Phi' => '934', 'phi' => '966', 'Pi' => '928', 'pi' => '960', 'piv' => '982', 'plusmn' => '177', 'pound' => '163', 'prime' => '8242', 'Prime' => '8243', 'prod' => '8719', 'prop' => '8733', 'Psi' => '936', 'psi' => '968', 'radic' => '8730', 'raquo' => '187', 'rarr' => '8594', 'rArr' => '8658', 'rceil' => '8969', 'rdquo' => '8221', 'real' => '8476', 'reg' => '174', 'rfloor' => '8971', 'Rho' => '929', 'rho' => '961', 'rlm' => '8207', 'rsaquo' => '8250', 'rsquo' => '8217', 'sbquo' => '8218', 'Scaron' => '352', 'scaron' => '353', 'sdot' => '8901', 'sect' => '167', 'shy' => '173', 'Sigma' => '931', 'sigma' => '963', 'sigmaf' => '962', 'sim' => '8764', 'spades' => '9824', 'sub' => '8834', 'sube' => '8838', 'sum' => '8721', 'sup' => '8835', 'sup1' => '185', 'sup2' => '178', 'sup3' => '179', 'supe' => '8839', 'szlig' => '223', 'Tau' => '932', 'tau' => '964', 'there4' => '8756', 'Theta' => '920', 'theta' => '952', 'thetasym' => '977', 'thinsp' => '8201', 'THORN' => '222', 'thorn' => '254', 'tilde' => '732', 'times' => '215', 'trade' => '8482', 'Uacute' => '218', 'uacute' => '250', 'uarr' => '8593', 'uArr' => '8657', 'Ucirc' => '219', 'ucirc' => '251', 'Ugrave' => '217', 'ugrave' => '249', 'uml' => '168', 'upsih' => '978', 'Upsilon' => '933', 'upsilon' => '965', 'Uuml' => '220', 'uuml' => '252', 'weierp' => '8472', 'Xi' => '926', 'xi' => '958', 'Yacute' => '221', 'yacute' => '253', 'yen' => '165', 'yuml' => '255', 'Yuml' => '376', 'Zeta' => '918', 'zeta' => '950', 'zwj' => '8205', 'zwnj' => '8204'];
-    static $rareEntNameAr   = ['Abreve' => '258', 'abreve' => '259', 'ac' => '8766', 'acd' => '8767', 'Acy' => '1040', 'acy' => '1072', 'af' => '8289', 'Afr' => '120068', 'afr' => '120094', 'aleph' => '8501', 'Amacr' => '256', 'amacr' => '257', 'amalg' => '10815', 'And' => '10835', 'andand' => '10837', 'andd' => '10844', 'andslope' => '10840', 'andv' => '10842', 'ange' => '10660', 'angle' => '8736', 'angmsd' => '8737', 'angmsdaa' => '10664', 'angmsdab' => '10665', 'angmsdac' => '10666', 'angmsdad' => '10667', 'angmsdae' => '10668', 'angmsdaf' => '10669', 'angmsdag' => '10670', 'angmsdah' => '10671', 'angrt' => '8735', 'angrtvb' => '8894', 'angrtvbd' => '10653', 'angsph' => '8738', 'angst' => '197', 'angzarr' => '9084', 'Aogon' => '260', 'aogon' => '261', 'Aopf' => '120120', 'aopf' => '120146', 'ap' => '8776', 'apacir' => '10863', 'apE' => '10864', 'ape' => '8778', 'apid' => '8779', 'ApplyFunction' => '8289', 'approx' => '8776', 'approxeq' => '8778', 'Ascr' => '119964', 'ascr' => '119990', 'Assign' => '8788', 'ast' => '42', 'asympeq' => '8781', 'awconint' => '8755', 'awint' => '10769', 'backcong' => '8780', 'backepsilon' => '1014', 'backprime' => '8245', 'backsim' => '8765', 'backsimeq' => '8909', 'Backslash' => '8726', 'Barv' => '10983', 'barvee' => '8893', 'barwed' => '8965', 'Barwed' => '8966', 'barwedge' => '8965', 'bbrk' => '9141', 'bbrktbrk' => '9142', 'bcong' => '8780', 'Bcy' => '1041', 'bcy' => '1073', 'becaus' => '8757', 'because' => '8757', 'Because' => '8757', 'bemptyv' => '10672', 'bepsi' => '1014', 'bernou' => '8492', 'Bernoullis' => '8492', 'beth' => '8502', 'between' => '8812', 'Bfr' => '120069', 'bfr' => '120095', 'bigcap' => '8898', 'bigcirc' => '9711', 'bigcup' => '8899', 'bigodot' => '10752', 'bigoplus' => '10753', 'bigotimes' => '10754', 'bigsqcup' => '10758', 'bigstar' => '9733', 'bigtriangledown' => '9661', 'bigtriangleup' => '9651', 'biguplus' => '10756', 'bigvee' => '8897', 'bigwedge' => '8896', 'bkarow' => '10509', 'blacklozenge' => '10731', 'blacksquare' => '9642', 'blacktriangle' => '9652', 'blacktriangledown' => '9662', 'blacktriangleleft' => '9666', 'blacktriangleright' => '9656', 'blank' => '9251', 'blk12' => '9618', 'blk14' => '9617', 'blk34' => '9619', 'block' => '9608', 'bNot' => '10989', 'bnot' => '8976', 'Bopf' => '120121', 'bopf' => '120147', 'bot' => '8869', 'bottom' => '8869', 'bowtie' => '8904', 'boxbox' => '10697', 'boxdl' => '9488', 'boxdL' => '9557', 'boxDl' => '9558', 'boxDL' => '9559', 'boxdr' => '9484', 'boxdR' => '9554', 'boxDr' => '9555', 'boxDR' => '9556', 'boxh' => '9472', 'boxH' => '9552', 'boxhd' => '9516', 'boxHd' => '9572', 'boxhD' => '9573', 'boxHD' => '9574', 'boxhu' => '9524', 'boxHu' => '9575', 'boxhU' => '9576', 'boxHU' => '9577', 'boxminus' => '8863', 'boxplus' => '8862', 'boxtimes' => '8864', 'boxul' => '9496', 'boxuL' => '9563', 'boxUl' => '9564', 'boxUL' => '9565', 'boxur' => '9492', 'boxuR' => '9560', 'boxUr' => '9561', 'boxUR' => '9562', 'boxv' => '9474', 'boxV' => '9553', 'boxvh' => '9532', 'boxvH' => '9578', 'boxVh' => '9579', 'boxVH' => '9580', 'boxvl' => '9508', 'boxvL' => '9569', 'boxVl' => '9570', 'boxVL' => '9571', 'boxvr' => '9500', 'boxvR' => '9566', 'boxVr' => '9567', 'boxVR' => '9568', 'bprime' => '8245', 'breve' => '728', 'Breve' => '728', 'bscr' => '119991', 'Bscr' => '8492', 'bsemi' => '8271', 'bsim' => '8765', 'bsime' => '8909', 'bsol' => '92', 'bsolb' => '10693', 'bsolhsub' => '10184', 'bullet' => '8226', 'bump' => '8782', 'bumpE' => '10926', 'bumpe' => '8783', 'Bumpeq' => '8782', 'bumpeq' => '8783', 'Cacute' => '262', 'cacute' => '263', 'Cap' => '8914', 'capand' => '10820', 'capbrcup' => '10825', 'capcap' => '10827', 'capcup' => '10823', 'capdot' => '10816', 'CapitalDifferentialD' => '8517', 'caret' => '8257', 'caron' => '711', 'Cayleys' => '8493', 'ccaps' => '10829', 'Ccaron' => '268', 'ccaron' => '269', 'Ccirc' => '264', 'ccirc' => '265', 'Cconint' => '8752', 'ccups' => '10828', 'ccupssm' => '10832', 'Cdot' => '266', 'cdot' => '267', 'Cedilla' => '184', 'cemptyv' => '10674', 'centerdot' => '183', 'CenterDot' => '183', 'cfr' => '120096', 'Cfr' => '8493', 'CHcy' => '1063', 'chcy' => '1095', 'check' => '10003', 'checkmark' => '10003', 'cir' => '9675', 'circeq' => '8791', 'circlearrowleft' => '8634', 'circlearrowright' => '8635', 'circledast' => '8859', 'circledcirc' => '8858', 'circleddash' => '8861', 'CircleDot' => '8857', 'circledR' => '174', 'circledS' => '9416', 'CircleMinus' => '8854', 'CirclePlus' => '8853', 'CircleTimes' => '8855', 'cirE' => '10691', 'cire' => '8791', 'cirfnint' => '10768', 'cirmid' => '10991', 'cirscir' => '10690', 'ClockwiseContourIntegral' => '8754', 'CloseCurlyDoubleQuote' => '8221', 'CloseCurlyQuote' => '8217', 'clubsuit' => '9827', 'colon' => '58', 'Colon' => '8759', 'Colone' => '10868', 'colone' => '8788', 'coloneq' => '8788', 'comma' => '44', 'commat' => '64', 'comp' => '8705', 'compfn' => '8728', 'complement' => '8705', 'complexes' => '8450', 'congdot' => '10861', 'Congruent' => '8801', 'conint' => '8750', 'Conint' => '8751', 'ContourIntegral' => '8750', 'copf' => '120148', 'Copf' => '8450', 'coprod' => '8720', 'Coproduct' => '8720', 'COPY' => '169', 'copysr' => '8471', 'CounterClockwiseContourIntegral' => '8755', 'cross' => '10007', 'Cross' => '10799', 'Cscr' => '119966', 'cscr' => '119992', 'csub' => '10959', 'csube' => '10961', 'csup' => '10960', 'csupe' => '10962', 'ctdot' => '8943', 'cudarrl' => '10552', 'cudarrr' => '10549', 'cuepr' => '8926', 'cuesc' => '8927', 'cularr' => '8630', 'cularrp' => '10557', 'Cup' => '8915', 'cupbrcap' => '10824', 'cupcap' => '10822', 'CupCap' => '8781', 'cupcup' => '10826', 'cupdot' => '8845', 'cupor' => '10821', 'curarr' => '8631', 'curarrm' => '10556', 'curlyeqprec' => '8926', 'curlyeqsucc' => '8927', 'curlyvee' => '8910', 'curlywedge' => '8911', 'curvearrowleft' => '8630', 'curvearrowright' => '8631', 'cuvee' => '8910', 'cuwed' => '8911', 'cwconint' => '8754', 'cwint' => '8753', 'cylcty' => '9005', 'daleth' => '8504', 'Darr' => '8609', 'dash' => '8208', 'Dashv' => '10980', 'dashv' => '8867', 'dbkarow' => '10511', 'dblac' => '733', 'Dcaron' => '270', 'dcaron' => '271', 'Dcy' => '1044', 'dcy' => '1076', 'DD' => '8517', 'dd' => '8518', 'ddagger' => '8225', 'ddarr' => '8650', 'DDotrahd' => '10513', 'ddotseq' => '10871', 'Del' => '8711', 'demptyv' => '10673', 'dfisht' => '10623', 'Dfr' => '120071', 'dfr' => '120097', 'dHar' => '10597', 'dharl' => '8643', 'dharr' => '8642', 'DiacriticalAcute' => '180', 'DiacriticalDot' => '729', 'DiacriticalDoubleAcute' => '733', 'DiacriticalGrave' => '96', 'DiacriticalTilde' => '732', 'diam' => '8900', 'diamond' => '8900', 'Diamond' => '8900', 'diamondsuit' => '9830', 'die' => '168', 'DifferentialD' => '8518', 'digamma' => '989', 'disin' => '8946', 'div' => '247', 'divideontimes' => '8903', 'divonx' => '8903', 'DJcy' => '1026', 'djcy' => '1106', 'dlcorn' => '8990', 'dlcrop' => '8973', 'dollar' => '36', 'Dopf' => '120123', 'dopf' => '120149', 'Dot' => '168', 'dot' => '729', 'DotDot' => '8412', 'doteq' => '8784', 'doteqdot' => '8785', 'DotEqual' => '8784', 'dotminus' => '8760', 'dotplus' => '8724', 'dotsquare' => '8865', 'doublebarwedge' => '8966', 'DoubleContourIntegral' => '8751', 'DoubleDot' => '168', 'DoubleDownArrow' => '8659', 'DoubleLeftArrow' => '8656', 'DoubleLeftRightArrow' => '8660', 'DoubleLeftTee' => '10980', 'DoubleLongLeftArrow' => '10232', 'DoubleLongLeftRightArrow' => '10234', 'DoubleLongRightArrow' => '10233', 'DoubleRightArrow' => '8658', 'DoubleRightTee' => '8872', 'DoubleUpArrow' => '8657', 'DoubleUpDownArrow' => '8661', 'DoubleVerticalBar' => '8741', 'downarrow' => '8595', 'DownArrow' => '8595', 'Downarrow' => '8659', 'DownArrowBar' => '10515', 'DownArrowUpArrow' => '8693', 'DownBreve' => '785', 'downdownarrows' => '8650', 'downharpoonleft' => '8643', 'downharpoonright' => '8642', 'DownLeftRightVector' => '10576', 'DownLeftTeeVector' => '10590', 'DownLeftVector' => '8637', 'DownLeftVectorBar' => '10582', 'DownRightTeeVector' => '10591', 'DownRightVector' => '8641', 'DownRightVectorBar' => '10583', 'DownTee' => '8868', 'DownTeeArrow' => '8615', 'drbkarow' => '10512', 'drcorn' => '8991', 'drcrop' => '8972', 'Dscr' => '119967', 'dscr' => '119993', 'DScy' => '1029', 'dscy' => '1109', 'dsol' => '10742', 'Dstrok' => '272', 'dstrok' => '273', 'dtdot' => '8945', 'dtri' => '9663', 'dtrif' => '9662', 'duarr' => '8693', 'duhar' => '10607', 'dwangle' => '10662', 'DZcy' => '1039', 'dzcy' => '1119', 'dzigrarr' => '10239', 'easter' => '10862', 'Ecaron' => '282', 'ecaron' => '283', 'ecir' => '8790', 'ecolon' => '8789', 'Ecy' => '1069', 'ecy' => '1101', 'eDDot' => '10871', 'Edot' => '278', 'edot' => '279', 'eDot' => '8785', 'ee' => '8519', 'efDot' => '8786', 'Efr' => '120072', 'efr' => '120098', 'eg' => '10906', 'egs' => '10902', 'egsdot' => '10904', 'el' => '10905', 'Element' => '8712', 'elinters' => '9191', 'ell' => '8467', 'els' => '10901', 'elsdot' => '10903', 'Emacr' => '274', 'emacr' => '275', 'emptyset' => '8709', 'EmptySmallSquare' => '9723', 'emptyv' => '8709', 'EmptyVerySmallSquare' => '9643', 'emsp13' => '8196', 'emsp14' => '8197', 'ENG' => '330', 'eng' => '331', 'Eogon' => '280', 'eogon' => '281', 'Eopf' => '120124', 'eopf' => '120150', 'epar' => '8917', 'eparsl' => '10723', 'eplus' => '10865', 'epsi' => '949', 'epsiv' => '1013', 'eqcirc' => '8790', 'eqcolon' => '8789', 'eqsim' => '8770', 'eqslantgtr' => '10902', 'eqslantless' => '10901', 'Equal' => '10869', 'equals' => '61', 'EqualTilde' => '8770', 'equest' => '8799', 'Equilibrium' => '8652', 'equivDD' => '10872', 'eqvparsl' => '10725', 'erarr' => '10609', 'erDot' => '8787', 'escr' => '8495', 'Escr' => '8496', 'esdot' => '8784', 'Esim' => '10867', 'esim' => '8770', 'excl' => '33', 'Exists' => '8707', 'expectation' => '8496', 'exponentiale' => '8519', 'ExponentialE' => '8519', 'fallingdotseq' => '8786', 'Fcy' => '1060', 'fcy' => '1092', 'female' => '9792', 'ffilig' => '64259', 'fflig' => '64256', 'ffllig' => '64260', 'Ffr' => '120073', 'ffr' => '120099', 'filig' => '64257', 'FilledSmallSquare' => '9724', 'FilledVerySmallSquare' => '9642', 'flat' => '9837', 'fllig' => '64258', 'fltns' => '9649', 'Fopf' => '120125', 'fopf' => '120151', 'ForAll' => '8704', 'fork' => '8916', 'forkv' => '10969', 'Fouriertrf' => '8497', 'fpartint' => '10765', 'frac13' => '8531', 'frac15' => '8533', 'frac16' => '8537', 'frac18' => '8539', 'frac23' => '8532', 'frac25' => '8534', 'frac35' => '8535', 'frac38' => '8540', 'frac45' => '8536', 'frac56' => '8538', 'frac58' => '8541', 'frac78' => '8542', 'frown' => '8994', 'fscr' => '119995', 'Fscr' => '8497', 'gacute' => '501', 'Gammad' => '988', 'gammad' => '989', 'gap' => '10886', 'Gbreve' => '286', 'gbreve' => '287', 'Gcedil' => '290', 'Gcirc' => '284', 'gcirc' => '285', 'Gcy' => '1043', 'gcy' => '1075', 'Gdot' => '288', 'gdot' => '289', 'gE' => '8807', 'gEl' => '10892', 'gel' => '8923', 'geq' => '8805', 'geqq' => '8807', 'geqslant' => '10878', 'ges' => '10878', 'gescc' => '10921', 'gesdot' => '10880', 'gesdoto' => '10882', 'gesdotol' => '10884', 'gesles' => '10900', 'Gfr' => '120074', 'gfr' => '120100', 'gg' => '8811', 'Gg' => '8921', 'ggg' => '8921', 'gimel' => '8503', 'GJcy' => '1027', 'gjcy' => '1107', 'gl' => '8823', 'gla' => '10917', 'glE' => '10898', 'glj' => '10916', 'gnap' => '10890', 'gnapprox' => '10890', 'gne' => '10888', 'gnE' => '8809', 'gneq' => '10888', 'gneqq' => '8809', 'gnsim' => '8935', 'Gopf' => '120126', 'gopf' => '120152', 'grave' => '96', 'GreaterEqual' => '8805', 'GreaterEqualLess' => '8923', 'GreaterFullEqual' => '8807', 'GreaterGreater' => '10914', 'GreaterLess' => '8823', 'GreaterSlantEqual' => '10878', 'GreaterTilde' => '8819', 'Gscr' => '119970', 'gscr' => '8458', 'gsim' => '8819', 'gsime' => '10894', 'gsiml' => '10896', 'Gt' => '8811', 'gtcc' => '10919', 'gtcir' => '10874', 'gtdot' => '8919', 'gtlPar' => '10645', 'gtquest' => '10876', 'gtrapprox' => '10886', 'gtrarr' => '10616', 'gtrdot' => '8919', 'gtreqless' => '8923', 'gtreqqless' => '10892', 'gtrless' => '8823', 'gtrsim' => '8819', 'Hacek' => '711', 'hairsp' => '8202', 'half' => '189', 'hamilt' => '8459', 'HARDcy' => '1066', 'hardcy' => '1098', 'harrcir' => '10568', 'harrw' => '8621', 'Hat' => '94', 'hbar' => '8463', 'Hcirc' => '292', 'hcirc' => '293', 'heartsuit' => '9829', 'hercon' => '8889', 'hfr' => '120101', 'Hfr' => '8460', 'HilbertSpace' => '8459', 'hksearow' => '10533', 'hkswarow' => '10534', 'hoarr' => '8703', 'homtht' => '8763', 'hookleftarrow' => '8617', 'hookrightarrow' => '8618', 'hopf' => '120153', 'Hopf' => '8461', 'horbar' => '8213', 'HorizontalLine' => '9472', 'hscr' => '119997', 'Hscr' => '8459', 'hslash' => '8463', 'Hstrok' => '294', 'hstrok' => '295', 'HumpDownHump' => '8782', 'HumpEqual' => '8783', 'hybull' => '8259', 'hyphen' => '8208', 'ic' => '8291', 'Icy' => '1048', 'icy' => '1080', 'Idot' => '304', 'IEcy' => '1045', 'iecy' => '1077', 'iff' => '8660', 'ifr' => '120102', 'Ifr' => '8465', 'ii' => '8520', 'iiiint' => '10764', 'iiint' => '8749', 'iinfin' => '10716', 'iiota' => '8489', 'IJlig' => '306', 'ijlig' => '307', 'Im' => '8465', 'Imacr' => '298', 'imacr' => '299', 'ImaginaryI' => '8520', 'imagline' => '8464', 'imagpart' => '8465', 'imath' => '305', 'imof' => '8887', 'imped' => '437', 'Implies' => '8658', 'in' => '8712', 'incare' => '8453', 'infintie' => '10717', 'inodot' => '305', 'Int' => '8748', 'intcal' => '8890', 'integers' => '8484', 'Integral' => '8747', 'intercal' => '8890', 'Intersection' => '8898', 'intlarhk' => '10775', 'intprod' => '10812', 'InvisibleComma' => '8291', 'InvisibleTimes' => '8290', 'IOcy' => '1025', 'iocy' => '1105', 'Iogon' => '302', 'iogon' => '303', 'Iopf' => '120128', 'iopf' => '120154', 'iprod' => '10812', 'iscr' => '119998', 'Iscr' => '8464', 'isindot' => '8949', 'isinE' => '8953', 'isins' => '8948', 'isinsv' => '8947', 'isinv' => '8712', 'it' => '8290', 'Itilde' => '296', 'itilde' => '297', 'Iukcy' => '1030', 'iukcy' => '1110', 'Jcirc' => '308', 'jcirc' => '309', 'Jcy' => '1049', 'jcy' => '1081', 'Jfr' => '120077', 'jfr' => '120103', 'jmath' => '567', 'Jopf' => '120129', 'jopf' => '120155', 'Jscr' => '119973', 'jscr' => '119999', 'Jsercy' => '1032', 'jsercy' => '1112', 'Jukcy' => '1028', 'jukcy' => '1108', 'kappav' => '1008', 'Kcedil' => '310', 'kcedil' => '311', 'Kcy' => '1050', 'kcy' => '1082', 'Kfr' => '120078', 'kfr' => '120104', 'kgreen' => '312', 'KHcy' => '1061', 'khcy' => '1093', 'KJcy' => '1036', 'kjcy' => '1116', 'Kopf' => '120130', 'kopf' => '120156', 'Kscr' => '119974', 'kscr' => '120000', 'lAarr' => '8666', 'Lacute' => '313', 'lacute' => '314', 'laemptyv' => '10676', 'lagran' => '8466', 'lang' => '10216', 'Lang' => '10218', 'langd' => '10641', 'langle' => '10216', 'lap' => '10885', 'Laplacetrf' => '8466', 'Larr' => '8606', 'larrb' => '8676', 'larrbfs' => '10527', 'larrfs' => '10525', 'larrhk' => '8617', 'larrlp' => '8619', 'larrpl' => '10553', 'larrsim' => '10611', 'larrtl' => '8610', 'lat' => '10923', 'latail' => '10521', 'lAtail' => '10523', 'late' => '10925', 'lbarr' => '10508', 'lBarr' => '10510', 'lbbrk' => '10098', 'lbrace' => '123', 'lbrack' => '91', 'lbrke' => '10635', 'lbrksld' => '10639', 'lbrkslu' => '10637', 'Lcaron' => '317', 'lcaron' => '318', 'Lcedil' => '315', 'lcedil' => '316', 'lcub' => '123', 'Lcy' => '1051', 'lcy' => '1083', 'ldca' => '10550', 'ldquor' => '8222', 'ldrdhar' => '10599', 'ldrushar' => '10571', 'ldsh' => '8626', 'lE' => '8806', 'LeftAngleBracket' => '10216', 'leftarrow' => '8592', 'LeftArrow' => '8592', 'Leftarrow' => '8656', 'LeftArrowBar' => '8676', 'LeftArrowRightArrow' => '8646', 'leftarrowtail' => '8610', 'LeftCeiling' => '8968', 'LeftDoubleBracket' => '10214', 'LeftDownTeeVector' => '10593', 'LeftDownVector' => '8643', 'LeftDownVectorBar' => '10585', 'LeftFloor' => '8970', 'leftharpoondown' => '8637', 'leftharpoonup' => '8636', 'leftleftarrows' => '8647', 'leftrightarrow' => '8596', 'LeftRightArrow' => '8596', 'Leftrightarrow' => '8660', 'leftrightarrows' => '8646', 'leftrightharpoons' => '8651', 'leftrightsquigarrow' => '8621', 'LeftRightVector' => '10574', 'LeftTee' => '8867', 'LeftTeeArrow' => '8612', 'LeftTeeVector' => '10586', 'leftthreetimes' => '8907', 'LeftTriangle' => '8882', 'LeftTriangleBar' => '10703', 'LeftTriangleEqual' => '8884', 'LeftUpDownVector' => '10577', 'LeftUpTeeVector' => '10592', 'LeftUpVector' => '8639', 'LeftUpVectorBar' => '10584', 'LeftVector' => '8636', 'LeftVectorBar' => '10578', 'lEg' => '10891', 'leg' => '8922', 'leq' => '8804', 'leqq' => '8806', 'leqslant' => '10877', 'les' => '10877', 'lescc' => '10920', 'lesdot' => '10879', 'lesdoto' => '10881', 'lesdotor' => '10883', 'lesges' => '10899', 'lessapprox' => '10885', 'lessdot' => '8918', 'lesseqgtr' => '8922', 'lesseqqgtr' => '10891', 'LessEqualGreater' => '8922', 'LessFullEqual' => '8806', 'LessGreater' => '8822', 'lessgtr' => '8822', 'LessLess' => '10913', 'lesssim' => '8818', 'LessSlantEqual' => '10877', 'LessTilde' => '8818', 'lfisht' => '10620', 'Lfr' => '120079', 'lfr' => '120105', 'lg' => '8822', 'lgE' => '10897', 'lHar' => '10594', 'lhard' => '8637', 'lharu' => '8636', 'lharul' => '10602', 'lhblk' => '9604', 'LJcy' => '1033', 'ljcy' => '1113', 'll' => '8810', 'Ll' => '8920', 'llarr' => '8647', 'llcorner' => '8990', 'Lleftarrow' => '8666', 'llhard' => '10603', 'lltri' => '9722', 'Lmidot' => '319', 'lmidot' => '320', 'lmoust' => '9136', 'lmoustache' => '9136', 'lnap' => '10889', 'lnapprox' => '10889', 'lne' => '10887', 'lnE' => '8808', 'lneq' => '10887', 'lneqq' => '8808', 'lnsim' => '8934', 'loang' => '10220', 'loarr' => '8701', 'lobrk' => '10214', 'longleftarrow' => '10229', 'LongLeftArrow' => '10229', 'Longleftarrow' => '10232', 'longleftrightarrow' => '10231', 'LongLeftRightArrow' => '10231', 'Longleftrightarrow' => '10234', 'longmapsto' => '10236', 'longrightarrow' => '10230', 'LongRightArrow' => '10230', 'Longrightarrow' => '10233', 'looparrowleft' => '8619', 'looparrowright' => '8620', 'lopar' => '10629', 'Lopf' => '120131', 'lopf' => '120157', 'loplus' => '10797', 'lotimes' => '10804', 'lowbar' => '95', 'LowerLeftArrow' => '8601', 'LowerRightArrow' => '8600', 'lozenge' => '9674', 'lozf' => '10731', 'lpar' => '40', 'lparlt' => '10643', 'lrarr' => '8646', 'lrcorner' => '8991', 'lrhar' => '8651', 'lrhard' => '10605', 'lrtri' => '8895', 'lscr' => '120001', 'Lscr' => '8466', 'lsh' => '8624', 'Lsh' => '8624', 'lsim' => '8818', 'lsime' => '10893', 'lsimg' => '10895', 'lsqb' => '91', 'lsquor' => '8218', 'Lstrok' => '321', 'lstrok' => '322', 'Lt' => '8810', 'ltcc' => '10918', 'ltcir' => '10873', 'ltdot' => '8918', 'lthree' => '8907', 'ltimes' => '8905', 'ltlarr' => '10614', 'ltquest' => '10875', 'ltri' => '9667', 'ltrie' => '8884', 'ltrif' => '9666', 'ltrPar' => '10646', 'lurdshar' => '10570', 'luruhar' => '10598', 'male' => '9794', 'malt' => '10016', 'maltese' => '10016', 'Map' => '10501', 'map' => '8614', 'mapsto' => '8614', 'mapstodown' => '8615', 'mapstoleft' => '8612', 'mapstoup' => '8613', 'marker' => '9646', 'mcomma' => '10793', 'Mcy' => '1052', 'mcy' => '1084', 'mDDot' => '8762', 'measuredangle' => '8737', 'MediumSpace' => '8287', 'Mellintrf' => '8499', 'Mfr' => '120080', 'mfr' => '120106', 'mho' => '8487', 'mid' => '8739', 'midast' => '42', 'midcir' => '10992', 'minusb' => '8863', 'minusd' => '8760', 'minusdu' => '10794', 'MinusPlus' => '8723', 'mlcp' => '10971', 'mldr' => '8230', 'mnplus' => '8723', 'models' => '8871', 'Mopf' => '120132', 'mopf' => '120158', 'mp' => '8723', 'mscr' => '120002', 'Mscr' => '8499', 'mstpos' => '8766', 'multimap' => '8888', 'mumap' => '8888', 'Nacute' => '323', 'nacute' => '324', 'nap' => '8777', 'napos' => '329', 'napprox' => '8777', 'natur' => '9838', 'natural' => '9838', 'naturals' => '8469', 'ncap' => '10819', 'Ncaron' => '327', 'ncaron' => '328', 'Ncedil' => '325', 'ncedil' => '326', 'ncong' => '8775', 'ncup' => '10818', 'Ncy' => '1053', 'ncy' => '1085', 'nearhk' => '10532', 'nearr' => '8599', 'neArr' => '8663', 'nearrow' => '8599', 'NegativeMediumSpace' => '8203', 'NegativeThickSpace' => '8203', 'NegativeThinSpace' => '8203', 'NegativeVeryThinSpace' => '8203', 'nequiv' => '8802', 'nesear' => '10536', 'NestedGreaterGreater' => '8811', 'NestedLessLess' => '8810', 'NewLine' => '10', 'nexist' => '8708', 'nexists' => '8708', 'Nfr' => '120081', 'nfr' => '120107', 'nge' => '8817', 'ngeq' => '8817', 'ngsim' => '8821', 'ngt' => '8815', 'ngtr' => '8815', 'nharr' => '8622', 'nhArr' => '8654', 'nhpar' => '10994', 'nis' => '8956', 'nisd' => '8954', 'niv' => '8715', 'NJcy' => '1034', 'njcy' => '1114', 'nlarr' => '8602', 'nlArr' => '8653', 'nldr' => '8229', 'nle' => '8816', 'nleftarrow' => '8602', 'nLeftarrow' => '8653', 'nleftrightarrow' => '8622', 'nLeftrightarrow' => '8654', 'nleq' => '8816', 'nless' => '8814', 'nlsim' => '8820', 'nlt' => '8814', 'nltri' => '8938', 'nltrie' => '8940', 'nmid' => '8740', 'NoBreak' => '8288', 'NonBreakingSpace' => '160', 'nopf' => '120159', 'Nopf' => '8469', 'Not' => '10988', 'NotCongruent' => '8802', 'NotCupCap' => '8813', 'NotDoubleVerticalBar' => '8742', 'NotElement' => '8713', 'NotEqual' => '8800', 'NotExists' => '8708', 'NotGreater' => '8815', 'NotGreaterEqual' => '8817', 'NotGreaterLess' => '8825', 'NotGreaterTilde' => '8821', 'notinva' => '8713', 'notinvb' => '8951', 'notinvc' => '8950', 'NotLeftTriangle' => '8938', 'NotLeftTriangleEqual' => '8940', 'NotLess' => '8814', 'NotLessEqual' => '8816', 'NotLessGreater' => '8824', 'NotLessTilde' => '8820', 'notni' => '8716', 'notniva' => '8716', 'notnivb' => '8958', 'notnivc' => '8957', 'NotPrecedes' => '8832', 'NotPrecedesSlantEqual' => '8928', 'NotReverseElement' => '8716', 'NotRightTriangle' => '8939', 'NotRightTriangleEqual' => '8941', 'NotSquareSubsetEqual' => '8930', 'NotSquareSupersetEqual' => '8931', 'NotSubsetEqual' => '8840', 'NotSucceeds' => '8833', 'NotSucceedsSlantEqual' => '8929', 'NotSupersetEqual' => '8841', 'NotTilde' => '8769', 'NotTildeEqual' => '8772', 'NotTildeFullEqual' => '8775', 'NotTildeTilde' => '8777', 'NotVerticalBar' => '8740', 'npar' => '8742', 'nparallel' => '8742', 'npolint' => '10772', 'npr' => '8832', 'nprcue' => '8928', 'nprec' => '8832', 'nrarr' => '8603', 'nrArr' => '8655', 'nrightarrow' => '8603', 'nRightarrow' => '8655', 'nrtri' => '8939', 'nrtrie' => '8941', 'nsc' => '8833', 'nsccue' => '8929', 'Nscr' => '119977', 'nscr' => '120003', 'nshortmid' => '8740', 'nshortparallel' => '8742', 'nsim' => '8769', 'nsime' => '8772', 'nsimeq' => '8772', 'nsmid' => '8740', 'nspar' => '8742', 'nsqsube' => '8930', 'nsqsupe' => '8931', 'nsube' => '8840', 'nsubseteq' => '8840', 'nsucc' => '8833', 'nsup' => '8837', 'nsupe' => '8841', 'nsupseteq' => '8841', 'ntgl' => '8825', 'ntlg' => '8824', 'ntriangleleft' => '8938', 'ntrianglelefteq' => '8940', 'ntriangleright' => '8939', 'ntrianglerighteq' => '8941', 'num' => '35', 'numero' => '8470', 'numsp' => '8199', 'nvdash' => '8876', 'nvDash' => '8877', 'nVdash' => '8878', 'nVDash' => '8879', 'nvHarr' => '10500', 'nvinfin' => '10718', 'nvlArr' => '10498', 'nvrArr' => '10499', 'nwarhk' => '10531', 'nwarr' => '8598', 'nwArr' => '8662', 'nwarrow' => '8598', 'nwnear' => '10535', 'oast' => '8859', 'ocir' => '8858', 'Ocy' => '1054', 'ocy' => '1086', 'odash' => '8861', 'Odblac' => '336', 'odblac' => '337', 'odiv' => '10808', 'odot' => '8857', 'odsold' => '10684', 'ofcir' => '10687', 'Ofr' => '120082', 'ofr' => '120108', 'ogon' => '731', 'ogt' => '10689', 'ohbar' => '10677', 'ohm' => '937', 'oint' => '8750', 'olarr' => '8634', 'olcir' => '10686', 'olcross' => '10683', 'olt' => '10688', 'Omacr' => '332', 'omacr' => '333', 'omid' => '10678', 'ominus' => '8854', 'Oopf' => '120134', 'oopf' => '120160', 'opar' => '10679', 'OpenCurlyDoubleQuote' => '8220', 'OpenCurlyQuote' => '8216', 'operp' => '10681', 'Or' => '10836', 'orarr' => '8635', 'ord' => '10845', 'order' => '8500', 'orderof' => '8500', 'origof' => '8886', 'oror' => '10838', 'orslope' => '10839', 'orv' => '10843', 'oS' => '9416', 'Oscr' => '119978', 'oscr' => '8500', 'osol' => '8856', 'Otimes' => '10807', 'otimesas' => '10806', 'ovbar' => '9021', 'OverBar' => '8254', 'OverBrace' => '9182', 'OverBracket' => '9140', 'OverParenthesis' => '9180', 'par' => '8741', 'parallel' => '8741', 'parsim' => '10995', 'parsl' => '11005', 'PartialD' => '8706', 'Pcy' => '1055', 'pcy' => '1087', 'percnt' => '37', 'period' => '46', 'pertenk' => '8241', 'Pfr' => '120083', 'pfr' => '120109', 'phiv' => '981', 'phmmat' => '8499', 'phone' => '9742', 'pitchfork' => '8916', 'planck' => '8463', 'planckh' => '8462', 'plankv' => '8463', 'plus' => '43', 'plusacir' => '10787', 'plusb' => '8862', 'pluscir' => '10786', 'plusdo' => '8724', 'plusdu' => '10789', 'pluse' => '10866', 'PlusMinus' => '177', 'plussim' => '10790', 'plustwo' => '10791', 'pm' => '177', 'Poincareplane' => '8460', 'pointint' => '10773', 'popf' => '120161', 'Popf' => '8473', 'Pr' => '10939', 'pr' => '8826', 'prap' => '10935', 'prcue' => '8828', 'pre' => '10927', 'prE' => '10931', 'prec' => '8826', 'precapprox' => '10935', 'preccurlyeq' => '8828', 'Precedes' => '8826', 'PrecedesEqual' => '10927', 'PrecedesSlantEqual' => '8828', 'PrecedesTilde' => '8830', 'preceq' => '10927', 'precnapprox' => '10937', 'precneqq' => '10933', 'precnsim' => '8936', 'precsim' => '8830', 'primes' => '8473', 'prnap' => '10937', 'prnE' => '10933', 'prnsim' => '8936', 'Product' => '8719', 'profalar' => '9006', 'profline' => '8978', 'profsurf' => '8979', 'Proportion' => '8759', 'Proportional' => '8733', 'propto' => '8733', 'prsim' => '8830', 'prurel' => '8880', 'Pscr' => '119979', 'pscr' => '120005', 'puncsp' => '8200', 'Qfr' => '120084', 'qfr' => '120110', 'qint' => '10764', 'qopf' => '120162', 'Qopf' => '8474', 'qprime' => '8279', 'Qscr' => '119980', 'qscr' => '120006', 'quaternions' => '8461', 'quatint' => '10774', 'quest' => '63', 'questeq' => '8799', 'rAarr' => '8667', 'Racute' => '340', 'racute' => '341', 'raemptyv' => '10675', 'rang' => '10217', 'Rang' => '10219', 'rangd' => '10642', 'range' => '10661', 'rangle' => '10217', 'Rarr' => '8608', 'rarrap' => '10613', 'rarrb' => '8677', 'rarrbfs' => '10528', 'rarrc' => '10547', 'rarrfs' => '10526', 'rarrhk' => '8618', 'rarrlp' => '8620', 'rarrpl' => '10565', 'rarrsim' => '10612', 'Rarrtl' => '10518', 'rarrtl' => '8611', 'rarrw' => '8605', 'ratail' => '10522', 'rAtail' => '10524', 'ratio' => '8758', 'rationals' => '8474', 'rbarr' => '10509', 'rBarr' => '10511', 'RBarr' => '10512', 'rbbrk' => '10099', 'rbrace' => '125', 'rbrack' => '93', 'rbrke' => '10636', 'rbrksld' => '10638', 'rbrkslu' => '10640', 'Rcaron' => '344', 'rcaron' => '345', 'Rcedil' => '342', 'rcedil' => '343', 'rcub' => '125', 'Rcy' => '1056', 'rcy' => '1088', 'rdca' => '10551', 'rdldhar' => '10601', 'rdquor' => '8221', 'rdsh' => '8627', 'Re' => '8476', 'realine' => '8475', 'realpart' => '8476', 'reals' => '8477', 'rect' => '9645', 'REG' => '174', 'ReverseElement' => '8715', 'ReverseEquilibrium' => '8651', 'ReverseUpEquilibrium' => '10607', 'rfisht' => '10621', 'rfr' => '120111', 'Rfr' => '8476', 'rHar' => '10596', 'rhard' => '8641', 'rharu' => '8640', 'rharul' => '10604', 'rhov' => '1009', 'RightAngleBracket' => '10217', 'rightarrow' => '8594', 'RightArrow' => '8594', 'Rightarrow' => '8658', 'RightArrowBar' => '8677', 'RightArrowLeftArrow' => '8644', 'rightarrowtail' => '8611', 'RightCeiling' => '8969', 'RightDoubleBracket' => '10215', 'RightDownTeeVector' => '10589', 'RightDownVector' => '8642', 'RightDownVectorBar' => '10581', 'RightFloor' => '8971', 'rightharpoondown' => '8641', 'rightharpoonup' => '8640', 'rightleftarrows' => '8644', 'rightleftharpoons' => '8652', 'rightrightarrows' => '8649', 'rightsquigarrow' => '8605', 'RightTee' => '8866', 'RightTeeArrow' => '8614', 'RightTeeVector' => '10587', 'rightthreetimes' => '8908', 'RightTriangle' => '8883', 'RightTriangleBar' => '10704', 'RightTriangleEqual' => '8885', 'RightUpDownVector' => '10575', 'RightUpTeeVector' => '10588', 'RightUpVector' => '8638', 'RightUpVectorBar' => '10580', 'RightVector' => '8640', 'RightVectorBar' => '10579', 'ring' => '730', 'risingdotseq' => '8787', 'rlarr' => '8644', 'rlhar' => '8652', 'rmoust' => '9137', 'rmoustache' => '9137', 'rnmid' => '10990', 'roang' => '10221', 'roarr' => '8702', 'robrk' => '10215', 'ropar' => '10630', 'ropf' => '120163', 'Ropf' => '8477', 'roplus' => '10798', 'rotimes' => '10805', 'RoundImplies' => '10608', 'rpar' => '41', 'rpargt' => '10644', 'rppolint' => '10770', 'rrarr' => '8649', 'Rrightarrow' => '8667', 'rscr' => '120007', 'Rscr' => '8475', 'rsh' => '8625', 'Rsh' => '8625', 'rsqb' => '93', 'rsquor' => '8217', 'rthree' => '8908', 'rtimes' => '8906', 'rtri' => '9657', 'rtrie' => '8885', 'rtrif' => '9656', 'rtriltri' => '10702', 'RuleDelayed' => '10740', 'ruluhar' => '10600', 'rx' => '8478', 'Sacute' => '346', 'sacute' => '347', 'Sc' => '10940', 'sc' => '8827', 'scap' => '10936', 'sccue' => '8829', 'sce' => '10928', 'scE' => '10932', 'Scedil' => '350', 'scedil' => '351', 'Scirc' => '348', 'scirc' => '349', 'scnap' => '10938', 'scnE' => '10934', 'scnsim' => '8937', 'scpolint' => '10771', 'scsim' => '8831', 'Scy' => '1057', 'scy' => '1089', 'sdotb' => '8865', 'sdote' => '10854', 'searhk' => '10533', 'searr' => '8600', 'seArr' => '8664', 'searrow' => '8600', 'semi' => '59', 'seswar' => '10537', 'setminus' => '8726', 'setmn' => '8726', 'sext' => '10038', 'Sfr' => '120086', 'sfr' => '120112', 'sfrown' => '8994', 'sharp' => '9839', 'SHCHcy' => '1065', 'shchcy' => '1097', 'SHcy' => '1064', 'shcy' => '1096', 'ShortDownArrow' => '8595', 'ShortLeftArrow' => '8592', 'shortmid' => '8739', 'shortparallel' => '8741', 'ShortRightArrow' => '8594', 'ShortUpArrow' => '8593', 'sigmav' => '962', 'simdot' => '10858', 'sime' => '8771', 'simeq' => '8771', 'simg' => '10910', 'simgE' => '10912', 'siml' => '10909', 'simlE' => '10911', 'simne' => '8774', 'simplus' => '10788', 'simrarr' => '10610', 'slarr' => '8592', 'SmallCircle' => '8728', 'smallsetminus' => '8726', 'smashp' => '10803', 'smeparsl' => '10724', 'smid' => '8739', 'smile' => '8995', 'smt' => '10922', 'smte' => '10924', 'SOFTcy' => '1068', 'softcy' => '1100', 'sol' => '47', 'solb' => '10692', 'solbar' => '9023', 'Sopf' => '120138', 'sopf' => '120164', 'spadesuit' => '9824', 'spar' => '8741', 'sqcap' => '8851', 'sqcup' => '8852', 'Sqrt' => '8730', 'sqsub' => '8847', 'sqsube' => '8849', 'sqsubset' => '8847', 'sqsubseteq' => '8849', 'sqsup' => '8848', 'sqsupe' => '8850', 'sqsupset' => '8848', 'sqsupseteq' => '8850', 'squ' => '9633', 'square' => '9633', 'Square' => '9633', 'SquareIntersection' => '8851', 'SquareSubset' => '8847', 'SquareSubsetEqual' => '8849', 'SquareSuperset' => '8848', 'SquareSupersetEqual' => '8850', 'SquareUnion' => '8852', 'squarf' => '9642', 'squf' => '9642', 'srarr' => '8594', 'Sscr' => '119982', 'sscr' => '120008', 'ssetmn' => '8726', 'ssmile' => '8995', 'sstarf' => '8902', 'Star' => '8902', 'star' => '9734', 'starf' => '9733', 'straightepsilon' => '1013', 'straightphi' => '981', 'strns' => '175', 'Sub' => '8912', 'subdot' => '10941', 'subE' => '10949', 'subedot' => '10947', 'submult' => '10945', 'subnE' => '10955', 'subne' => '8842', 'subplus' => '10943', 'subrarr' => '10617', 'subset' => '8834', 'Subset' => '8912', 'subseteq' => '8838', 'subseteqq' => '10949', 'SubsetEqual' => '8838', 'subsetneq' => '8842', 'subsetneqq' => '10955', 'subsim' => '10951', 'subsub' => '10965', 'subsup' => '10963', 'succ' => '8827', 'succapprox' => '10936', 'succcurlyeq' => '8829', 'Succeeds' => '8827', 'SucceedsEqual' => '10928', 'SucceedsSlantEqual' => '8829', 'SucceedsTilde' => '8831', 'succeq' => '10928', 'succnapprox' => '10938', 'succneqq' => '10934', 'succnsim' => '8937', 'succsim' => '8831', 'SuchThat' => '8715', 'Sum' => '8721', 'sung' => '9834', 'Sup' => '8913', 'supdot' => '10942', 'supdsub' => '10968', 'supE' => '10950', 'supedot' => '10948', 'Superset' => '8835', 'SupersetEqual' => '8839', 'suphsol' => '10185', 'suphsub' => '10967', 'suplarr' => '10619', 'supmult' => '10946', 'supnE' => '10956', 'supne' => '8843', 'supplus' => '10944', 'supset' => '8835', 'Supset' => '8913', 'supseteq' => '8839', 'supseteqq' => '10950', 'supsetneq' => '8843', 'supsetneqq' => '10956', 'supsim' => '10952', 'supsub' => '10964', 'supsup' => '10966', 'swarhk' => '10534', 'swarr' => '8601', 'swArr' => '8665', 'swarrow' => '8601', 'swnwar' => '10538', 'Tab' => '9', 'target' => '8982', 'tbrk' => '9140', 'Tcaron' => '356', 'tcaron' => '357', 'Tcedil' => '354', 'tcedil' => '355', 'Tcy' => '1058', 'tcy' => '1090', 'tdot' => '8411', 'telrec' => '8981', 'Tfr' => '120087', 'tfr' => '120113', 'therefore' => '8756', 'Therefore' => '8756', 'thetav' => '977', 'thickapprox' => '8776', 'thicksim' => '8764', 'ThinSpace' => '8201', 'thkap' => '8776', 'thksim' => '8764', 'Tilde' => '8764', 'TildeEqual' => '8771', 'TildeFullEqual' => '8773', 'TildeTilde' => '8776', 'timesb' => '8864', 'timesbar' => '10801', 'timesd' => '10800', 'tint' => '8749', 'toea' => '10536', 'top' => '8868', 'topbot' => '9014', 'topcir' => '10993', 'Topf' => '120139', 'topf' => '120165', 'topfork' => '10970', 'tosa' => '10537', 'tprime' => '8244', 'TRADE' => '8482', 'triangle' => '9653', 'triangledown' => '9663', 'triangleleft' => '9667', 'trianglelefteq' => '8884', 'triangleq' => '8796', 'triangleright' => '9657', 'trianglerighteq' => '8885', 'tridot' => '9708', 'trie' => '8796', 'triminus' => '10810', 'TripleDot' => '8411', 'triplus' => '10809', 'trisb' => '10701', 'tritime' => '10811', 'trpezium' => '9186', 'Tscr' => '119983', 'tscr' => '120009', 'TScy' => '1062', 'tscy' => '1094', 'TSHcy' => '1035', 'tshcy' => '1115', 'Tstrok' => '358', 'tstrok' => '359', 'twixt' => '8812', 'twoheadleftarrow' => '8606', 'twoheadrightarrow' => '8608', 'Uarr' => '8607', 'Uarrocir' => '10569', 'Ubrcy' => '1038', 'ubrcy' => '1118', 'Ubreve' => '364', 'ubreve' => '365', 'Ucy' => '1059', 'ucy' => '1091', 'udarr' => '8645', 'Udblac' => '368', 'udblac' => '369', 'udhar' => '10606', 'ufisht' => '10622', 'Ufr' => '120088', 'ufr' => '120114', 'uHar' => '10595', 'uharl' => '8639', 'uharr' => '8638', 'uhblk' => '9600', 'ulcorn' => '8988', 'ulcorner' => '8988', 'ulcrop' => '8975', 'ultri' => '9720', 'Umacr' => '362', 'umacr' => '363', 'UnderBar' => '95', 'UnderBrace' => '9183', 'UnderBracket' => '9141', 'UnderParenthesis' => '9181', 'Union' => '8899', 'UnionPlus' => '8846', 'Uogon' => '370', 'uogon' => '371', 'Uopf' => '120140', 'uopf' => '120166', 'uparrow' => '8593', 'UpArrow' => '8593', 'Uparrow' => '8657', 'UpArrowBar' => '10514', 'UpArrowDownArrow' => '8645', 'updownarrow' => '8597', 'UpDownArrow' => '8597', 'Updownarrow' => '8661', 'UpEquilibrium' => '10606', 'upharpoonleft' => '8639', 'upharpoonright' => '8638', 'uplus' => '8846', 'UpperLeftArrow' => '8598', 'UpperRightArrow' => '8599', 'upsi' => '965', 'Upsi' => '978', 'UpTee' => '8869', 'UpTeeArrow' => '8613', 'upuparrows' => '8648', 'urcorn' => '8989', 'urcorner' => '8989', 'urcrop' => '8974', 'Uring' => '366', 'uring' => '367', 'urtri' => '9721', 'Uscr' => '119984', 'uscr' => '120010', 'utdot' => '8944', 'Utilde' => '360', 'utilde' => '361', 'utri' => '9653', 'utrif' => '9652', 'uuarr' => '8648', 'uwangle' => '10663', 'vangrt' => '10652', 'varepsilon' => '1013', 'varkappa' => '1008', 'varnothing' => '8709', 'varphi' => '981', 'varpi' => '982', 'varpropto' => '8733', 'varr' => '8597', 'vArr' => '8661', 'varrho' => '1009', 'varsigma' => '962', 'vartheta' => '977', 'vartriangleleft' => '8882', 'vartriangleright' => '8883', 'vBar' => '10984', 'Vbar' => '10987', 'vBarv' => '10985', 'Vcy' => '1042', 'vcy' => '1074', 'vdash' => '8866', 'vDash' => '8872', 'Vdash' => '8873', 'VDash' => '8875', 'Vdashl' => '10982', 'vee' => '8744', 'Vee' => '8897', 'veebar' => '8891', 'veeeq' => '8794', 'vellip' => '8942', 'verbar' => '124', 'Verbar' => '8214', 'vert' => '124', 'Vert' => '8214', 'VerticalBar' => '8739', 'VerticalLine' => '124', 'VerticalSeparator' => '10072', 'VerticalTilde' => '8768', 'VeryThinSpace' => '8202', 'Vfr' => '120089', 'vfr' => '120115', 'vltri' => '8882', 'Vopf' => '120141', 'vopf' => '120167', 'vprop' => '8733', 'vrtri' => '8883', 'Vscr' => '119985', 'vscr' => '120011', 'Vvdash' => '8874', 'vzigzag' => '10650', 'Wcirc' => '372', 'wcirc' => '373', 'wedbar' => '10847', 'wedge' => '8743', 'Wedge' => '8896', 'wedgeq' => '8793', 'Wfr' => '120090', 'wfr' => '120116', 'Wopf' => '120142', 'wopf' => '120168', 'wp' => '8472', 'wr' => '8768', 'wreath' => '8768', 'Wscr' => '119986', 'wscr' => '120012', 'xcap' => '8898', 'xcirc' => '9711', 'xcup' => '8899', 'xdtri' => '9661', 'Xfr' => '120091', 'xfr' => '120117', 'xharr' => '10231', 'xhArr' => '10234', 'xlarr' => '10229', 'xlArr' => '10232', 'xmap' => '10236', 'xnis' => '8955', 'xodot' => '10752', 'Xopf' => '120143', 'xopf' => '120169', 'xoplus' => '10753', 'xotime' => '10754', 'xrarr' => '10230', 'xrArr' => '10233', 'Xscr' => '119987', 'xscr' => '120013', 'xsqcup' => '10758', 'xuplus' => '10756', 'xutri' => '9651', 'xvee' => '8897', 'xwedge' => '8896', 'YAcy' => '1071', 'yacy' => '1103', 'Ycirc' => '374', 'ycirc' => '375', 'Ycy' => '1067', 'ycy' => '1099', 'Yfr' => '120092', 'yfr' => '120118', 'YIcy' => '1031', 'yicy' => '1111', 'Yopf' => '120144', 'yopf' => '120170', 'Yscr' => '119988', 'yscr' => '120014', 'YUcy' => '1070', 'yucy' => '1102', 'Zacute' => '377', 'zacute' => '378', 'Zcaron' => '381', 'zcaron' => '382', 'Zcy' => '1047', 'zcy' => '1079', 'Zdot' => '379', 'zdot' => '380', 'zeetrf' => '8488', 'ZeroWidthSpace' => '8203', 'zfr' => '120119', 'Zfr' => '8488', 'ZHcy' => '1046', 'zhcy' => '1078', 'zigrarr' => '8669', 'zopf' => '120171', 'Zopf' => '8484', 'Zscr' => '119989', 'zscr' => '120015'];
-    if ('#' != $t[0]) {
+    static $rareEntNameAr = ['Abreve' => '258', 'abreve' => '259', 'ac' => '8766', 'acd' => '8767', 'Acy' => '1040', 'acy' => '1072', 'af' => '8289', 'Afr' => '120068', 'afr' => '120094', 'aleph' => '8501', 'Amacr' => '256', 'amacr' => '257', 'amalg' => '10815', 'And' => '10835', 'andand' => '10837', 'andd' => '10844', 'andslope' => '10840', 'andv' => '10842', 'ange' => '10660', 'angle' => '8736', 'angmsd' => '8737', 'angmsdaa' => '10664', 'angmsdab' => '10665', 'angmsdac' => '10666', 'angmsdad' => '10667', 'angmsdae' => '10668', 'angmsdaf' => '10669', 'angmsdag' => '10670', 'angmsdah' => '10671', 'angrt' => '8735', 'angrtvb' => '8894', 'angrtvbd' => '10653', 'angsph' => '8738', 'angst' => '197', 'angzarr' => '9084', 'Aogon' => '260', 'aogon' => '261', 'Aopf' => '120120', 'aopf' => '120146', 'ap' => '8776', 'apacir' => '10863', 'apE' => '10864', 'ape' => '8778', 'apid' => '8779', 'ApplyFunction' => '8289', 'approx' => '8776', 'approxeq' => '8778', 'Ascr' => '119964', 'ascr' => '119990', 'Assign' => '8788', 'ast' => '42', 'asympeq' => '8781', 'awconint' => '8755', 'awint' => '10769', 'backcong' => '8780', 'backepsilon' => '1014', 'backprime' => '8245', 'backsim' => '8765', 'backsimeq' => '8909', 'Backslash' => '8726', 'Barv' => '10983', 'barvee' => '8893', 'barwed' => '8965', 'Barwed' => '8966', 'barwedge' => '8965', 'bbrk' => '9141', 'bbrktbrk' => '9142', 'bcong' => '8780', 'Bcy' => '1041', 'bcy' => '1073', 'becaus' => '8757', 'because' => '8757', 'Because' => '8757', 'bemptyv' => '10672', 'bepsi' => '1014', 'bernou' => '8492', 'Bernoullis' => '8492', 'beth' => '8502', 'between' => '8812', 'Bfr' => '120069', 'bfr' => '120095', 'bigcap' => '8898', 'bigcirc' => '9711', 'bigcup' => '8899', 'bigodot' => '10752', 'bigoplus' => '10753', 'bigotimes' => '10754', 'bigsqcup' => '10758', 'bigstar' => '9733', 'bigtriangledown' => '9661', 'bigtriangleup' => '9651', 'biguplus' => '10756', 'bigvee' => '8897', 'bigwedge' => '8896', 'bkarow' => '10509', 'blacklozenge' => '10731', 'blacksquare' => '9642', 'blacktriangle' => '9652', 'blacktriangledown' => '9662', 'blacktriangleleft' => '9666', 'blacktriangleright' => '9656', 'blank' => '9251', 'blk12' => '9618', 'blk14' => '9617', 'blk34' => '9619', 'block' => '9608', 'bNot' => '10989', 'bnot' => '8976', 'Bopf' => '120121', 'bopf' => '120147', 'bot' => '8869', 'bottom' => '8869', 'bowtie' => '8904', 'boxbox' => '10697', 'boxdl' => '9488', 'boxdL' => '9557', 'boxDl' => '9558', 'boxDL' => '9559', 'boxdr' => '9484', 'boxdR' => '9554', 'boxDr' => '9555', 'boxDR' => '9556', 'boxh' => '9472', 'boxH' => '9552', 'boxhd' => '9516', 'boxHd' => '9572', 'boxhD' => '9573', 'boxHD' => '9574', 'boxhu' => '9524', 'boxHu' => '9575', 'boxhU' => '9576', 'boxHU' => '9577', 'boxminus' => '8863', 'boxplus' => '8862', 'boxtimes' => '8864', 'boxul' => '9496', 'boxuL' => '9563', 'boxUl' => '9564', 'boxUL' => '9565', 'boxur' => '9492', 'boxuR' => '9560', 'boxUr' => '9561', 'boxUR' => '9562', 'boxv' => '9474', 'boxV' => '9553', 'boxvh' => '9532', 'boxvH' => '9578', 'boxVh' => '9579', 'boxVH' => '9580', 'boxvl' => '9508', 'boxvL' => '9569', 'boxVl' => '9570', 'boxVL' => '9571', 'boxvr' => '9500', 'boxvR' => '9566', 'boxVr' => '9567', 'boxVR' => '9568', 'bprime' => '8245', 'breve' => '728', 'Breve' => '728', 'bscr' => '119991', 'Bscr' => '8492', 'bsemi' => '8271', 'bsim' => '8765', 'bsime' => '8909', 'bsol' => '92', 'bsolb' => '10693', 'bsolhsub' => '10184', 'bullet' => '8226', 'bump' => '8782', 'bumpE' => '10926', 'bumpe' => '8783', 'Bumpeq' => '8782', 'bumpeq' => '8783', 'Cacute' => '262', 'cacute' => '263', 'Cap' => '8914', 'capand' => '10820', 'capbrcup' => '10825', 'capcap' => '10827', 'capcup' => '10823', 'capdot' => '10816', 'CapitalDifferentialD' => '8517', 'caret' => '8257', 'caron' => '711', 'Cayleys' => '8493', 'ccaps' => '10829', 'Ccaron' => '268', 'ccaron' => '269', 'Ccirc' => '264', 'ccirc' => '265', 'Cconint' => '8752', 'ccups' => '10828', 'ccupssm' => '10832', 'Cdot' => '266', 'cdot' => '267', 'Cedilla' => '184', 'cemptyv' => '10674', 'centerdot' => '183', 'CenterDot' => '183', 'cfr' => '120096', 'Cfr' => '8493', 'CHcy' => '1063', 'chcy' => '1095', 'check' => '10003', 'checkmark' => '10003', 'cir' => '9675', 'circeq' => '8791', 'circlearrowleft' => '8634', 'circlearrowright' => '8635', 'circledast' => '8859', 'circledcirc' => '8858', 'circleddash' => '8861', 'CircleDot' => '8857', 'circledR' => '174', 'circledS' => '9416', 'CircleMinus' => '8854', 'CirclePlus' => '8853', 'CircleTimes' => '8855', 'cirE' => '10691', 'cire' => '8791', 'cirfnint' => '10768', 'cirmid' => '10991', 'cirscir' => '10690', 'ClockwiseContourIntegral' => '8754', 'CloseCurlyDoubleQuote' => '8221', 'CloseCurlyQuote' => '8217', 'clubsuit' => '9827', 'colon' => '58', 'Colon' => '8759', 'Colone' => '10868', 'colone' => '8788', 'coloneq' => '8788', 'comma' => '44', 'commat' => '64', 'comp' => '8705', 'compfn' => '8728', 'complement' => '8705', 'complexes' => '8450', 'congdot' => '10861', 'Congruent' => '8801', 'conint' => '8750', 'Conint' => '8751', 'ContourIntegral' => '8750', 'copf' => '120148', 'Copf' => '8450', 'coprod' => '8720', 'Coproduct' => '8720', 'COPY' => '169', 'copysr' => '8471', 'CounterClockwiseContourIntegral' => '8755', 'cross' => '10007', 'Cross' => '10799', 'Cscr' => '119966', 'cscr' => '119992', 'csub' => '10959', 'csube' => '10961', 'csup' => '10960', 'csupe' => '10962', 'ctdot' => '8943', 'cudarrl' => '10552', 'cudarrr' => '10549', 'cuepr' => '8926', 'cuesc' => '8927', 'cularr' => '8630', 'cularrp' => '10557', 'Cup' => '8915', 'cupbrcap' => '10824', 'cupcap' => '10822', 'CupCap' => '8781', 'cupcup' => '10826', 'cupdot' => '8845', 'cupor' => '10821', 'curarr' => '8631', 'curarrm' => '10556', 'curlyeqprec' => '8926', 'curlyeqsucc' => '8927', 'curlyvee' => '8910', 'curlywedge' => '8911', 'curvearrowleft' => '8630', 'curvearrowright' => '8631', 'cuvee' => '8910', 'cuwed' => '8911', 'cwconint' => '8754', 'cwint' => '8753', 'cylcty' => '9005', 'daleth' => '8504', 'Darr' => '8609', 'dash' => '8208', 'Dashv' => '10980', 'dashv' => '8867', 'dbkarow' => '10511', 'dblac' => '733', 'Dcaron' => '270', 'dcaron' => '271', 'Dcy' => '1044', 'dcy' => '1076', 'DD' => '8517', 'dd' => '8518', 'ddagger' => '8225', 'ddarr' => '8650', 'DDotrahd' => '10513', 'ddotseq' => '10871', 'Del' => '8711', 'demptyv' => '10673', 'dfisht' => '10623', 'Dfr' => '120071', 'dfr' => '120097', 'dHar' => '10597', 'dharl' => '8643', 'dharr' => '8642', 'DiacriticalAcute' => '180', 'DiacriticalDot' => '729', 'DiacriticalDoubleAcute' => '733', 'DiacriticalGrave' => '96', 'DiacriticalTilde' => '732', 'diam' => '8900', 'diamond' => '8900', 'Diamond' => '8900', 'diamondsuit' => '9830', 'die' => '168', 'DifferentialD' => '8518', 'digamma' => '989', 'disin' => '8946', 'div' => '247', 'divideontimes' => '8903', 'divonx' => '8903', 'DJcy' => '1026', 'djcy' => '1106', 'dlcorn' => '8990', 'dlcrop' => '8973', 'dollar' => '36', 'Dopf' => '120123', 'dopf' => '120149', 'Dot' => '168', 'dot' => '729', 'DotDot' => '8412', 'doteq' => '8784', 'doteqdot' => '8785', 'DotEqual' => '8784', 'dotminus' => '8760', 'dotplus' => '8724', 'dotsquare' => '8865', 'doublebarwedge' => '8966', 'DoubleContourIntegral' => '8751', 'DoubleDot' => '168', 'DoubleDownArrow' => '8659', 'DoubleLeftArrow' => '8656', 'DoubleLeftRightArrow' => '8660', 'DoubleLeftTee' => '10980', 'DoubleLongLeftArrow' => '10232', 'DoubleLongLeftRightArrow' => '10234', 'DoubleLongRightArrow' => '10233', 'DoubleRightArrow' => '8658', 'DoubleRightTee' => '8872', 'DoubleUpArrow' => '8657', 'DoubleUpDownArrow' => '8661', 'DoubleVerticalBar' => '8741', 'downarrow' => '8595', 'DownArrow' => '8595', 'Downarrow' => '8659', 'DownArrowBar' => '10515', 'DownArrowUpArrow' => '8693', 'DownBreve' => '785', 'downdownarrows' => '8650', 'downharpoonleft' => '8643', 'downharpoonright' => '8642', 'DownLeftRightVector' => '10576', 'DownLeftTeeVector' => '10590', 'DownLeftVector' => '8637', 'DownLeftVectorBar' => '10582', 'DownRightTeeVector' => '10591', 'DownRightVector' => '8641', 'DownRightVectorBar' => '10583', 'DownTee' => '8868', 'DownTeeArrow' => '8615', 'drbkarow' => '10512', 'drcorn' => '8991', 'drcrop' => '8972', 'Dscr' => '119967', 'dscr' => '119993', 'DScy' => '1029', 'dscy' => '1109', 'dsol' => '10742', 'Dstrok' => '272', 'dstrok' => '273', 'dtdot' => '8945', 'dtri' => '9663', 'dtrif' => '9662', 'duarr' => '8693', 'duhar' => '10607', 'dwangle' => '10662', 'DZcy' => '1039', 'dzcy' => '1119', 'dzigrarr' => '10239', 'easter' => '10862', 'Ecaron' => '282', 'ecaron' => '283', 'ecir' => '8790', 'ecolon' => '8789', 'Ecy' => '1069', 'ecy' => '1101', 'eDDot' => '10871', 'Edot' => '278', 'edot' => '279', 'eDot' => '8785', 'ee' => '8519', 'efDot' => '8786', 'Efr' => '120072', 'efr' => '120098', 'eg' => '10906', 'egs' => '10902', 'egsdot' => '10904', 'el' => '10905', 'Element' => '8712', 'elinters' => '9191', 'ell' => '8467', 'els' => '10901', 'elsdot' => '10903', 'Emacr' => '274', 'emacr' => '275', 'emptyset' => '8709', 'EmptySmallSquare' => '9723', 'emptyv' => '8709', 'EmptyVerySmallSquare' => '9643', 'emsp13' => '8196', 'emsp14' => '8197', 'ENG' => '330', 'eng' => '331', 'Eogon' => '280', 'eogon' => '281', 'Eopf' => '120124', 'eopf' => '120150', 'epar' => '8917', 'eparsl' => '10723', 'eplus' => '10865', 'epsi' => '949', 'epsiv' => '1013', 'eqcirc' => '8790', 'eqcolon' => '8789', 'eqsim' => '8770', 'eqslantgtr' => '10902', 'eqslantless' => '10901', 'Equal' => '10869', 'equals' => '61', 'EqualTilde' => '8770', 'equest' => '8799', 'Equilibrium' => '8652', 'equivDD' => '10872', 'eqvparsl' => '10725', 'erarr' => '10609', 'erDot' => '8787', 'escr' => '8495', 'Escr' => '8496', 'esdot' => '8784', 'Esim' => '10867', 'esim' => '8770', 'excl' => '33', 'Exists' => '8707', 'expectation' => '8496', 'exponentiale' => '8519', 'ExponentialE' => '8519', 'fallingdotseq' => '8786', 'Fcy' => '1060', 'fcy' => '1092', 'female' => '9792', 'ffilig' => '64259', 'fflig' => '64256', 'ffllig' => '64260', 'Ffr' => '120073', 'ffr' => '120099', 'filig' => '64257', 'FilledSmallSquare' => '9724', 'FilledVerySmallSquare' => '9642', 'flat' => '9837', 'fllig' => '64258', 'fltns' => '9649', 'Fopf' => '120125', 'fopf' => '120151', 'ForAll' => '8704', 'fork' => '8916', 'forkv' => '10969', 'Fouriertrf' => '8497', 'fpartint' => '10765', 'frac13' => '8531', 'frac15' => '8533', 'frac16' => '8537', 'frac18' => '8539', 'frac23' => '8532', 'frac25' => '8534', 'frac35' => '8535', 'frac38' => '8540', 'frac45' => '8536', 'frac56' => '8538', 'frac58' => '8541', 'frac78' => '8542', 'frown' => '8994', 'fscr' => '119995', 'Fscr' => '8497', 'gacute' => '501', 'Gammad' => '988', 'gammad' => '989', 'gap' => '10886', 'Gbreve' => '286', 'gbreve' => '287', 'Gcedil' => '290', 'Gcirc' => '284', 'gcirc' => '285', 'Gcy' => '1043', 'gcy' => '1075', 'Gdot' => '288', 'gdot' => '289', 'gE' => '8807', 'gEl' => '10892', 'gel' => '8923', 'geq' => '8805', 'geqq' => '8807', 'geqslant' => '10878', 'ges' => '10878', 'gescc' => '10921', 'gesdot' => '10880', 'gesdoto' => '10882', 'gesdotol' => '10884', 'gesles' => '10900', 'Gfr' => '120074', 'gfr' => '120100', 'gg' => '8811', 'Gg' => '8921', 'ggg' => '8921', 'gimel' => '8503', 'GJcy' => '1027', 'gjcy' => '1107', 'gl' => '8823', 'gla' => '10917', 'glE' => '10898', 'glj' => '10916', 'gnap' => '10890', 'gnapprox' => '10890', 'gne' => '10888', 'gnE' => '8809', 'gneq' => '10888', 'gneqq' => '8809', 'gnsim' => '8935', 'Gopf' => '120126', 'gopf' => '120152', 'grave' => '96', 'GreaterEqual' => '8805', 'GreaterEqualLess' => '8923', 'GreaterFullEqual' => '8807', 'GreaterGreater' => '10914', 'GreaterLess' => '8823', 'GreaterSlantEqual' => '10878', 'GreaterTilde' => '8819', 'Gscr' => '119970', 'gscr' => '8458', 'gsim' => '8819', 'gsime' => '10894', 'gsiml' => '10896', 'Gt' => '8811', 'gtcc' => '10919', 'gtcir' => '10874', 'gtdot' => '8919', 'gtlPar' => '10645', 'gtquest' => '10876', 'gtrapprox' => '10886', 'gtrarr' => '10616', 'gtrdot' => '8919', 'gtreqless' => '8923', 'gtreqqless' => '10892', 'gtrless' => '8823', 'gtrsim' => '8819', 'Hacek' => '711', 'hairsp' => '8202', 'half' => '189', 'hamilt' => '8459', 'HARDcy' => '1066', 'hardcy' => '1098', 'harrcir' => '10568', 'harrw' => '8621', 'Hat' => '94', 'hbar' => '8463', 'Hcirc' => '292', 'hcirc' => '293', 'heartsuit' => '9829', 'hercon' => '8889', 'hfr' => '120101', 'Hfr' => '8460', 'HilbertSpace' => '8459', 'hksearow' => '10533', 'hkswarow' => '10534', 'hoarr' => '8703', 'homtht' => '8763', 'hookleftarrow' => '8617', 'hookrightarrow' => '8618', 'hopf' => '120153', 'Hopf' => '8461', 'horbar' => '8213', 'HorizontalLine' => '9472', 'hscr' => '119997', 'Hscr' => '8459', 'hslash' => '8463', 'Hstrok' => '294', 'hstrok' => '295', 'HumpDownHump' => '8782', 'HumpEqual' => '8783', 'hybull' => '8259', 'hyphen' => '8208', 'ic' => '8291', 'Icy' => '1048', 'icy' => '1080', 'Idot' => '304', 'IEcy' => '1045', 'iecy' => '1077', 'iff' => '8660', 'ifr' => '120102', 'Ifr' => '8465', 'ii' => '8520', 'iiiint' => '10764', 'iiint' => '8749', 'iinfin' => '10716', 'iiota' => '8489', 'IJlig' => '306', 'ijlig' => '307', 'Im' => '8465', 'Imacr' => '298', 'imacr' => '299', 'ImaginaryI' => '8520', 'imagline' => '8464', 'imagpart' => '8465', 'imath' => '305', 'imof' => '8887', 'imped' => '437', 'Implies' => '8658', 'in' => '8712', 'incare' => '8453', 'infintie' => '10717', 'inodot' => '305', 'Int' => '8748', 'intcal' => '8890', 'integers' => '8484', 'Integral' => '8747', 'intercal' => '8890', 'Intersection' => '8898', 'intlarhk' => '10775', 'intprod' => '10812', 'InvisibleComma' => '8291', 'InvisibleTimes' => '8290', 'IOcy' => '1025', 'iocy' => '1105', 'Iogon' => '302', 'iogon' => '303', 'Iopf' => '120128', 'iopf' => '120154', 'iprod' => '10812', 'iscr' => '119998', 'Iscr' => '8464', 'isindot' => '8949', 'isinE' => '8953', 'isins' => '8948', 'isinsv' => '8947', 'isinv' => '8712', 'it' => '8290', 'Itilde' => '296', 'itilde' => '297', 'Iukcy' => '1030', 'iukcy' => '1110', 'Jcirc' => '308', 'jcirc' => '309', 'Jcy' => '1049', 'jcy' => '1081', 'Jfr' => '120077', 'jfr' => '120103', 'jmath' => '567', 'Jopf' => '120129', 'jopf' => '120155', 'Jscr' => '119973', 'jscr' => '119999', 'Jsercy' => '1032', 'jsercy' => '1112', 'Jukcy' => '1028', 'jukcy' => '1108', 'kappav' => '1008', 'Kcedil' => '310', 'kcedil' => '311', 'Kcy' => '1050', 'kcy' => '1082', 'Kfr' => '120078', 'kfr' => '120104', 'kgreen' => '312', 'KHcy' => '1061', 'khcy' => '1093', 'KJcy' => '1036', 'kjcy' => '1116', 'Kopf' => '120130', 'kopf' => '120156', 'Kscr' => '119974', 'kscr' => '120000', 'lAarr' => '8666', 'Lacute' => '313', 'lacute' => '314', 'laemptyv' => '10676', 'lagran' => '8466', 'lang' => '10216', 'Lang' => '10218', 'langd' => '10641', 'langle' => '10216', 'lap' => '10885', 'Laplacetrf' => '8466', 'Larr' => '8606', 'larrb' => '8676', 'larrbfs' => '10527', 'larrfs' => '10525', 'larrhk' => '8617', 'larrlp' => '8619', 'larrpl' => '10553', 'larrsim' => '10611', 'larrtl' => '8610', 'lat' => '10923', 'latail' => '10521', 'lAtail' => '10523', 'late' => '10925', 'lbarr' => '10508', 'lBarr' => '10510', 'lbbrk' => '10098', 'lbrace' => '123', 'lbrack' => '91', 'lbrke' => '10635', 'lbrksld' => '10639', 'lbrkslu' => '10637', 'Lcaron' => '317', 'lcaron' => '318', 'Lcedil' => '315', 'lcedil' => '316', 'lcub' => '123', 'Lcy' => '1051', 'lcy' => '1083', 'ldca' => '10550', 'ldquor' => '8222', 'ldrdhar' => '10599', 'ldrushar' => '10571', 'ldsh' => '8626', 'lE' => '8806', 'LeftAngleBracket' => '10216', 'leftarrow' => '8592', 'LeftArrow' => '8592', 'Leftarrow' => '8656', 'LeftArrowBar' => '8676', 'LeftArrowRightArrow' => '8646', 'leftarrowtail' => '8610', 'LeftCeiling' => '8968', 'LeftDoubleBracket' => '10214', 'LeftDownTeeVector' => '10593', 'LeftDownVector' => '8643', 'LeftDownVectorBar' => '10585', 'LeftFloor' => '8970', 'leftharpoondown' => '8637', 'leftharpoonup' => '8636', 'leftleftarrows' => '8647', 'leftrightarrow' => '8596', 'LeftRightArrow' => '8596', 'Leftrightarrow' => '8660', 'leftrightarrows' => '8646', 'leftrightharpoons' => '8651', 'leftrightsquigarrow' => '8621', 'LeftRightVector' => '10574', 'LeftTee' => '8867', 'LeftTeeArrow' => '8612', 'LeftTeeVector' => '10586', 'leftthreetimes' => '8907', 'LeftTriangle' => '8882', 'LeftTriangleBar' => '10703', 'LeftTriangleEqual' => '8884', 'LeftUpDownVector' => '10577', 'LeftUpTeeVector' => '10592', 'LeftUpVector' => '8639', 'LeftUpVectorBar' => '10584', 'LeftVector' => '8636', 'LeftVectorBar' => '10578', 'lEg' => '10891', 'leg' => '8922', 'leq' => '8804', 'leqq' => '8806', 'leqslant' => '10877', 'les' => '10877', 'lescc' => '10920', 'lesdot' => '10879', 'lesdoto' => '10881', 'lesdotor' => '10883', 'lesges' => '10899', 'lessapprox' => '10885', 'lessdot' => '8918', 'lesseqgtr' => '8922', 'lesseqqgtr' => '10891', 'LessEqualGreater' => '8922', 'LessFullEqual' => '8806', 'LessGreater' => '8822', 'lessgtr' => '8822', 'LessLess' => '10913', 'lesssim' => '8818', 'LessSlantEqual' => '10877', 'LessTilde' => '8818', 'lfisht' => '10620', 'Lfr' => '120079', 'lfr' => '120105', 'lg' => '8822', 'lgE' => '10897', 'lHar' => '10594', 'lhard' => '8637', 'lharu' => '8636', 'lharul' => '10602', 'lhblk' => '9604', 'LJcy' => '1033', 'ljcy' => '1113', 'll' => '8810', 'Ll' => '8920', 'llarr' => '8647', 'llcorner' => '8990', 'Lleftarrow' => '8666', 'llhard' => '10603', 'lltri' => '9722', 'Lmidot' => '319', 'lmidot' => '320', 'lmoust' => '9136', 'lmoustache' => '9136', 'lnap' => '10889', 'lnapprox' => '10889', 'lne' => '10887', 'lnE' => '8808', 'lneq' => '10887', 'lneqq' => '8808', 'lnsim' => '8934', 'loang' => '10220', 'loarr' => '8701', 'lobrk' => '10214', 'longleftarrow' => '10229', 'LongLeftArrow' => '10229', 'Longleftarrow' => '10232', 'longleftrightarrow' => '10231', 'LongLeftRightArrow' => '10231', 'Longleftrightarrow' => '10234', 'longmapsto' => '10236', 'longrightarrow' => '10230', 'LongRightArrow' => '10230', 'Longrightarrow' => '10233', 'looparrowleft' => '8619', 'looparrowright' => '8620', 'lopar' => '10629', 'Lopf' => '120131', 'lopf' => '120157', 'loplus' => '10797', 'lotimes' => '10804', 'lowbar' => '95', 'LowerLeftArrow' => '8601', 'LowerRightArrow' => '8600', 'lozenge' => '9674', 'lozf' => '10731', 'lpar' => '40', 'lparlt' => '10643', 'lrarr' => '8646', 'lrcorner' => '8991', 'lrhar' => '8651', 'lrhard' => '10605', 'lrtri' => '8895', 'lscr' => '120001', 'Lscr' => '8466', 'lsh' => '8624', 'Lsh' => '8624', 'lsim' => '8818', 'lsime' => '10893', 'lsimg' => '10895', 'lsqb' => '91', 'lsquor' => '8218', 'Lstrok' => '321', 'lstrok' => '322', 'Lt' => '8810', 'ltcc' => '10918', 'ltcir' => '10873', 'ltdot' => '8918', 'lthree' => '8907', 'ltimes' => '8905', 'ltlarr' => '10614', 'ltquest' => '10875', 'ltri' => '9667', 'ltrie' => '8884', 'ltrif' => '9666', 'ltrPar' => '10646', 'lurdshar' => '10570', 'luruhar' => '10598', 'male' => '9794', 'malt' => '10016', 'maltese' => '10016', 'Map' => '10501', 'map' => '8614', 'mapsto' => '8614', 'mapstodown' => '8615', 'mapstoleft' => '8612', 'mapstoup' => '8613', 'marker' => '9646', 'mcomma' => '10793', 'Mcy' => '1052', 'mcy' => '1084', 'mDDot' => '8762', 'measuredangle' => '8737', 'MediumSpace' => '8287', 'Mellintrf' => '8499', 'Mfr' => '120080', 'mfr' => '120106', 'mho' => '8487', 'mid' => '8739', 'midast' => '42', 'midcir' => '10992', 'minusb' => '8863', 'minusd' => '8760', 'minusdu' => '10794', 'MinusPlus' => '8723', 'mlcp' => '10971', 'mldr' => '8230', 'mnplus' => '8723', 'models' => '8871', 'Mopf' => '120132', 'mopf' => '120158', 'mp' => '8723', 'mscr' => '120002', 'Mscr' => '8499', 'mstpos' => '8766', 'multimap' => '8888', 'mumap' => '8888', 'Nacute' => '323', 'nacute' => '324', 'nap' => '8777', 'napos' => '329', 'napprox' => '8777', 'natur' => '9838', 'natural' => '9838', 'naturals' => '8469', 'ncap' => '10819', 'Ncaron' => '327', 'ncaron' => '328', 'Ncedil' => '325', 'ncedil' => '326', 'ncong' => '8775', 'ncup' => '10818', 'Ncy' => '1053', 'ncy' => '1085', 'nearhk' => '10532', 'nearr' => '8599', 'neArr' => '8663', 'nearrow' => '8599', 'NegativeMediumSpace' => '8203', 'NegativeThickSpace' => '8203', 'NegativeThinSpace' => '8203', 'NegativeVeryThinSpace' => '8203', 'nequiv' => '8802', 'nesear' => '10536', 'NestedGreaterGreater' => '8811', 'NestedLessLess' => '8810', 'NewLine' => '10', 'nexist' => '8708', 'nexists' => '8708', 'Nfr' => '120081', 'nfr' => '120107', 'nge' => '8817', 'ngeq' => '8817', 'ngsim' => '8821', 'ngt' => '8815', 'ngtr' => '8815', 'nharr' => '8622', 'nhArr' => '8654', 'nhpar' => '10994', 'nis' => '8956', 'nisd' => '8954', 'niv' => '8715', 'NJcy' => '1034', 'njcy' => '1114', 'nlarr' => '8602', 'nlArr' => '8653', 'nldr' => '8229', 'nle' => '8816', 'nleftarrow' => '8602', 'nLeftarrow' => '8653', 'nleftrightarrow' => '8622', 'nLeftrightarrow' => '8654', 'nleq' => '8816', 'nless' => '8814', 'nlsim' => '8820', 'nlt' => '8814', 'nltri' => '8938', 'nltrie' => '8940', 'nmid' => '8740', 'NoBreak' => '8288', 'NonBreakingSpace' => '160', 'nopf' => '120159', 'Nopf' => '8469', 'Not' => '10988', 'NotCongruent' => '8802', 'NotCupCap' => '8813', 'NotDoubleVerticalBar' => '8742', 'NotElement' => '8713', 'NotEqual' => '8800', 'NotExists' => '8708', 'NotGreater' => '8815', 'NotGreaterEqual' => '8817', 'NotGreaterLess' => '8825', 'NotGreaterTilde' => '8821', 'notinva' => '8713', 'notinvb' => '8951', 'notinvc' => '8950', 'NotLeftTriangle' => '8938', 'NotLeftTriangleEqual' => '8940', 'NotLess' => '8814', 'NotLessEqual' => '8816', 'NotLessGreater' => '8824', 'NotLessTilde' => '8820', 'notni' => '8716', 'notniva' => '8716', 'notnivb' => '8958', 'notnivc' => '8957', 'NotPrecedes' => '8832', 'NotPrecedesSlantEqual' => '8928', 'NotReverseElement' => '8716', 'NotRightTriangle' => '8939', 'NotRightTriangleEqual' => '8941', 'NotSquareSubsetEqual' => '8930', 'NotSquareSupersetEqual' => '8931', 'NotSubsetEqual' => '8840', 'NotSucceeds' => '8833', 'NotSucceedsSlantEqual' => '8929', 'NotSupersetEqual' => '8841', 'NotTilde' => '8769', 'NotTildeEqual' => '8772', 'NotTildeFullEqual' => '8775', 'NotTildeTilde' => '8777', 'NotVerticalBar' => '8740', 'npar' => '8742', 'nparallel' => '8742', 'npolint' => '10772', 'npr' => '8832', 'nprcue' => '8928', 'nprec' => '8832', 'nrarr' => '8603', 'nrArr' => '8655', 'nrightarrow' => '8603', 'nRightarrow' => '8655', 'nrtri' => '8939', 'nrtrie' => '8941', 'nsc' => '8833', 'nsccue' => '8929', 'Nscr' => '119977', 'nscr' => '120003', 'nshortmid' => '8740', 'nshortparallel' => '8742', 'nsim' => '8769', 'nsime' => '8772', 'nsimeq' => '8772', 'nsmid' => '8740', 'nspar' => '8742', 'nsqsube' => '8930', 'nsqsupe' => '8931', 'nsube' => '8840', 'nsubseteq' => '8840', 'nsucc' => '8833', 'nsup' => '8837', 'nsupe' => '8841', 'nsupseteq' => '8841', 'ntgl' => '8825', 'ntlg' => '8824', 'ntriangleleft' => '8938', 'ntrianglelefteq' => '8940', 'ntriangleright' => '8939', 'ntrianglerighteq' => '8941', 'num' => '35', 'numero' => '8470', 'numsp' => '8199', 'nvdash' => '8876', 'nvDash' => '8877', 'nVdash' => '8878', 'nVDash' => '8879', 'nvHarr' => '10500', 'nvinfin' => '10718', 'nvlArr' => '10498', 'nvrArr' => '10499', 'nwarhk' => '10531', 'nwarr' => '8598', 'nwArr' => '8662', 'nwarrow' => '8598', 'nwnear' => '10535', 'oast' => '8859', 'ocir' => '8858', 'Ocy' => '1054', 'ocy' => '1086', 'odash' => '8861', 'Odblac' => '336', 'odblac' => '337', 'odiv' => '10808', 'odot' => '8857', 'odsold' => '10684', 'ofcir' => '10687', 'Ofr' => '120082', 'ofr' => '120108', 'ogon' => '731', 'ogt' => '10689', 'ohbar' => '10677', 'ohm' => '937', 'oint' => '8750', 'olarr' => '8634', 'olcir' => '10686', 'olcross' => '10683', 'olt' => '10688', 'Omacr' => '332', 'omacr' => '333', 'omid' => '10678', 'ominus' => '8854', 'Oopf' => '120134', 'oopf' => '120160', 'opar' => '10679', 'OpenCurlyDoubleQuote' => '8220', 'OpenCurlyQuote' => '8216', 'operp' => '10681', 'Or' => '10836', 'orarr' => '8635', 'ord' => '10845', 'order' => '8500', 'orderof' => '8500', 'origof' => '8886', 'oror' => '10838', 'orslope' => '10839', 'orv' => '10843', 'oS' => '9416', 'Oscr' => '119978', 'oscr' => '8500', 'osol' => '8856', 'Otimes' => '10807', 'otimesas' => '10806', 'ovbar' => '9021', 'OverBar' => '8254', 'OverBrace' => '9182', 'OverBracket' => '9140', 'OverParenthesis' => '9180', 'par' => '8741', 'parallel' => '8741', 'parsim' => '10995', 'parsl' => '11005', 'PartialD' => '8706', 'Pcy' => '1055', 'pcy' => '1087', 'percnt' => '37', 'period' => '46', 'pertenk' => '8241', 'Pfr' => '120083', 'pfr' => '120109', 'phiv' => '981', 'phmmat' => '8499', 'phone' => '9742', 'pitchfork' => '8916', 'planck' => '8463', 'planckh' => '8462', 'plankv' => '8463', 'plus' => '43', 'plusacir' => '10787', 'plusb' => '8862', 'pluscir' => '10786', 'plusdo' => '8724', 'plusdu' => '10789', 'pluse' => '10866', 'PlusMinus' => '177', 'plussim' => '10790', 'plustwo' => '10791', 'pm' => '177', 'Poincareplane' => '8460', 'pointint' => '10773', 'popf' => '120161', 'Popf' => '8473', 'Pr' => '10939', 'pr' => '8826', 'prap' => '10935', 'prcue' => '8828', 'pre' => '10927', 'prE' => '10931', 'prec' => '8826', 'precapprox' => '10935', 'preccurlyeq' => '8828', 'Precedes' => '8826', 'PrecedesEqual' => '10927', 'PrecedesSlantEqual' => '8828', 'PrecedesTilde' => '8830', 'preceq' => '10927', 'precnapprox' => '10937', 'precneqq' => '10933', 'precnsim' => '8936', 'precsim' => '8830', 'primes' => '8473', 'prnap' => '10937', 'prnE' => '10933', 'prnsim' => '8936', 'Product' => '8719', 'profalar' => '9006', 'profline' => '8978', 'profsurf' => '8979', 'Proportion' => '8759', 'Proportional' => '8733', 'propto' => '8733', 'prsim' => '8830', 'prurel' => '8880', 'Pscr' => '119979', 'pscr' => '120005', 'puncsp' => '8200', 'Qfr' => '120084', 'qfr' => '120110', 'qint' => '10764', 'qopf' => '120162', 'Qopf' => '8474', 'qprime' => '8279', 'Qscr' => '119980', 'qscr' => '120006', 'quaternions' => '8461', 'quatint' => '10774', 'quest' => '63', 'questeq' => '8799', 'rAarr' => '8667', 'Racute' => '340', 'racute' => '341', 'raemptyv' => '10675', 'rang' => '10217', 'Rang' => '10219', 'rangd' => '10642', 'range' => '10661', 'rangle' => '10217', 'Rarr' => '8608', 'rarrap' => '10613', 'rarrb' => '8677', 'rarrbfs' => '10528', 'rarrc' => '10547', 'rarrfs' => '10526', 'rarrhk' => '8618', 'rarrlp' => '8620', 'rarrpl' => '10565', 'rarrsim' => '10612', 'Rarrtl' => '10518', 'rarrtl' => '8611', 'rarrw' => '8605', 'ratail' => '10522', 'rAtail' => '10524', 'ratio' => '8758', 'rationals' => '8474', 'rbarr' => '10509', 'rBarr' => '10511', 'RBarr' => '10512', 'rbbrk' => '10099', 'rbrace' => '125', 'rbrack' => '93', 'rbrke' => '10636', 'rbrksld' => '10638', 'rbrkslu' => '10640', 'Rcaron' => '344', 'rcaron' => '345', 'Rcedil' => '342', 'rcedil' => '343', 'rcub' => '125', 'Rcy' => '1056', 'rcy' => '1088', 'rdca' => '10551', 'rdldhar' => '10601', 'rdquor' => '8221', 'rdsh' => '8627', 'Re' => '8476', 'realine' => '8475', 'realpart' => '8476', 'reals' => '8477', 'rect' => '9645', 'REG' => '174', 'ReverseElement' => '8715', 'ReverseEquilibrium' => '8651', 'ReverseUpEquilibrium' => '10607', 'rfisht' => '10621', 'rfr' => '120111', 'Rfr' => '8476', 'rHar' => '10596', 'rhard' => '8641', 'rharu' => '8640', 'rharul' => '10604', 'rhov' => '1009', 'RightAngleBracket' => '10217', 'rightarrow' => '8594', 'RightArrow' => '8594', 'Rightarrow' => '8658', 'RightArrowBar' => '8677', 'RightArrowLeftArrow' => '8644', 'rightarrowtail' => '8611', 'RightCeiling' => '8969', 'RightDoubleBracket' => '10215', 'RightDownTeeVector' => '10589', 'RightDownVector' => '8642', 'RightDownVectorBar' => '10581', 'RightFloor' => '8971', 'rightharpoondown' => '8641', 'rightharpoonup' => '8640', 'rightleftarrows' => '8644', 'rightleftharpoons' => '8652', 'rightrightarrows' => '8649', 'rightsquigarrow' => '8605', 'RightTee' => '8866', 'RightTeeArrow' => '8614', 'RightTeeVector' => '10587', 'rightthreetimes' => '8908', 'RightTriangle' => '8883', 'RightTriangleBar' => '10704', 'RightTriangleEqual' => '8885', 'RightUpDownVector' => '10575', 'RightUpTeeVector' => '10588', 'RightUpVector' => '8638', 'RightUpVectorBar' => '10580', 'RightVector' => '8640', 'RightVectorBar' => '10579', 'ring' => '730', 'risingdotseq' => '8787', 'rlarr' => '8644', 'rlhar' => '8652', 'rmoust' => '9137', 'rmoustache' => '9137', 'rnmid' => '10990', 'roang' => '10221', 'roarr' => '8702', 'robrk' => '10215', 'ropar' => '10630', 'ropf' => '120163', 'Ropf' => '8477', 'roplus' => '10798', 'rotimes' => '10805', 'RoundImplies' => '10608', 'rpar' => '41', 'rpargt' => '10644', 'rppolint' => '10770', 'rrarr' => '8649', 'Rrightarrow' => '8667', 'rscr' => '120007', 'Rscr' => '8475', 'rsh' => '8625', 'Rsh' => '8625', 'rsqb' => '93', 'rsquor' => '8217', 'rthree' => '8908', 'rtimes' => '8906', 'rtri' => '9657', 'rtrie' => '8885', 'rtrif' => '9656', 'rtriltri' => '10702', 'RuleDelayed' => '10740', 'ruluhar' => '10600', 'rx' => '8478', 'Sacute' => '346', 'sacute' => '347', 'Sc' => '10940', 'sc' => '8827', 'scap' => '10936', 'sccue' => '8829', 'sce' => '10928', 'scE' => '10932', 'Scedil' => '350', 'scedil' => '351', 'Scirc' => '348', 'scirc' => '349', 'scnap' => '10938', 'scnE' => '10934', 'scnsim' => '8937', 'scpolint' => '10771', 'scsim' => '8831', 'Scy' => '1057', 'scy' => '1089', 'sdotb' => '8865', 'sdote' => '10854', 'searhk' => '10533', 'searr' => '8600', 'seArr' => '8664', 'searrow' => '8600', 'semi' => '59', 'seswar' => '10537', 'setminus' => '8726', 'setmn' => '8726', 'sext' => '10038', 'Sfr' => '120086', 'sfr' => '120112', 'sfrown' => '8994', 'sharp' => '9839', 'SHCHcy' => '1065', 'shchcy' => '1097', 'SHcy' => '1064', 'shcy' => '1096', 'ShortDownArrow' => '8595', 'ShortLeftArrow' => '8592', 'shortmid' => '8739', 'shortparallel' => '8741', 'ShortRightArrow' => '8594', 'ShortUpArrow' => '8593', 'sigmav' => '962', 'simdot' => '10858', 'sime' => '8771', 'simeq' => '8771', 'simg' => '10910', 'simgE' => '10912', 'siml' => '10909', 'simlE' => '10911', 'simne' => '8774', 'simplus' => '10788', 'simrarr' => '10610', 'slarr' => '8592', 'SmallCircle' => '8728', 'smallsetminus' => '8726', 'smashp' => '10803', 'smeparsl' => '10724', 'smid' => '8739', 'smile' => '8995', 'smt' => '10922', 'smte' => '10924', 'SOFTcy' => '1068', 'softcy' => '1100', 'sol' => '47', 'solb' => '10692', 'solbar' => '9023', 'Sopf' => '120138', 'sopf' => '120164', 'spadesuit' => '9824', 'spar' => '8741', 'sqcap' => '8851', 'sqcup' => '8852', 'Sqrt' => '8730', 'sqsub' => '8847', 'sqsube' => '8849', 'sqsubset' => '8847', 'sqsubseteq' => '8849', 'sqsup' => '8848', 'sqsupe' => '8850', 'sqsupset' => '8848', 'sqsupseteq' => '8850', 'squ' => '9633', 'square' => '9633', 'Square' => '9633', 'SquareIntersection' => '8851', 'SquareSubset' => '8847', 'SquareSubsetEqual' => '8849', 'SquareSuperset' => '8848', 'SquareSupersetEqual' => '8850', 'SquareUnion' => '8852', 'squarf' => '9642', 'squf' => '9642', 'srarr' => '8594', 'Sscr' => '119982', 'sscr' => '120008', 'ssetmn' => '8726', 'ssmile' => '8995', 'sstarf' => '8902', 'Star' => '8902', 'star' => '9734', 'starf' => '9733', 'straightepsilon' => '1013', 'straightphi' => '981', 'strns' => '175', 'Sub' => '8912', 'subdot' => '10941', 'subE' => '10949', 'subedot' => '10947', 'submult' => '10945', 'subnE' => '10955', 'subne' => '8842', 'subplus' => '10943', 'subrarr' => '10617', 'subset' => '8834', 'Subset' => '8912', 'subseteq' => '8838', 'subseteqq' => '10949', 'SubsetEqual' => '8838', 'subsetneq' => '8842', 'subsetneqq' => '10955', 'subsim' => '10951', 'subsub' => '10965', 'subsup' => '10963', 'succ' => '8827', 'succapprox' => '10936', 'succcurlyeq' => '8829', 'Succeeds' => '8827', 'SucceedsEqual' => '10928', 'SucceedsSlantEqual' => '8829', 'SucceedsTilde' => '8831', 'succeq' => '10928', 'succnapprox' => '10938', 'succneqq' => '10934', 'succnsim' => '8937', 'succsim' => '8831', 'SuchThat' => '8715', 'Sum' => '8721', 'sung' => '9834', 'Sup' => '8913', 'supdot' => '10942', 'supdsub' => '10968', 'supE' => '10950', 'supedot' => '10948', 'Superset' => '8835', 'SupersetEqual' => '8839', 'suphsol' => '10185', 'suphsub' => '10967', 'suplarr' => '10619', 'supmult' => '10946', 'supnE' => '10956', 'supne' => '8843', 'supplus' => '10944', 'supset' => '8835', 'Supset' => '8913', 'supseteq' => '8839', 'supseteqq' => '10950', 'supsetneq' => '8843', 'supsetneqq' => '10956', 'supsim' => '10952', 'supsub' => '10964', 'supsup' => '10966', 'swarhk' => '10534', 'swarr' => '8601', 'swArr' => '8665', 'swarrow' => '8601', 'swnwar' => '10538', 'Tab' => '9', 'target' => '8982', 'tbrk' => '9140', 'Tcaron' => '356', 'tcaron' => '357', 'Tcedil' => '354', 'tcedil' => '355', 'Tcy' => '1058', 'tcy' => '1090', 'tdot' => '8411', 'telrec' => '8981', 'Tfr' => '120087', 'tfr' => '120113', 'therefore' => '8756', 'Therefore' => '8756', 'thetav' => '977', 'thickapprox' => '8776', 'thicksim' => '8764', 'ThinSpace' => '8201', 'thkap' => '8776', 'thksim' => '8764', 'Tilde' => '8764', 'TildeEqual' => '8771', 'TildeFullEqual' => '8773', 'TildeTilde' => '8776', 'timesb' => '8864', 'timesbar' => '10801', 'timesd' => '10800', 'tint' => '8749', 'toea' => '10536', 'top' => '8868', 'topbot' => '9014', 'topcir' => '10993', 'Topf' => '120139', 'topf' => '120165', 'topfork' => '10970', 'tosa' => '10537', 'tprime' => '8244', 'TRADE' => '8482', 'triangle' => '9653', 'triangledown' => '9663', 'triangleleft' => '9667', 'trianglelefteq' => '8884', 'triangleq' => '8796', 'triangleright' => '9657', 'trianglerighteq' => '8885', 'tridot' => '9708', 'trie' => '8796', 'triminus' => '10810', 'TripleDot' => '8411', 'triplus' => '10809', 'trisb' => '10701', 'tritime' => '10811', 'trpezium' => '9186', 'Tscr' => '119983', 'tscr' => '120009', 'TScy' => '1062', 'tscy' => '1094', 'TSHcy' => '1035', 'tshcy' => '1115', 'Tstrok' => '358', 'tstrok' => '359', 'twixt' => '8812', 'twoheadleftarrow' => '8606', 'twoheadrightarrow' => '8608', 'Uarr' => '8607', 'Uarrocir' => '10569', 'Ubrcy' => '1038', 'ubrcy' => '1118', 'Ubreve' => '364', 'ubreve' => '365', 'Ucy' => '1059', 'ucy' => '1091', 'udarr' => '8645', 'Udblac' => '368', 'udblac' => '369', 'udhar' => '10606', 'ufisht' => '10622', 'Ufr' => '120088', 'ufr' => '120114', 'uHar' => '10595', 'uharl' => '8639', 'uharr' => '8638', 'uhblk' => '9600', 'ulcorn' => '8988', 'ulcorner' => '8988', 'ulcrop' => '8975', 'ultri' => '9720', 'Umacr' => '362', 'umacr' => '363', 'UnderBar' => '95', 'UnderBrace' => '9183', 'UnderBracket' => '9141', 'UnderParenthesis' => '9181', 'Union' => '8899', 'UnionPlus' => '8846', 'Uogon' => '370', 'uogon' => '371', 'Uopf' => '120140', 'uopf' => '120166', 'uparrow' => '8593', 'UpArrow' => '8593', 'Uparrow' => '8657', 'UpArrowBar' => '10514', 'UpArrowDownArrow' => '8645', 'updownarrow' => '8597', 'UpDownArrow' => '8597', 'Updownarrow' => '8661', 'UpEquilibrium' => '10606', 'upharpoonleft' => '8639', 'upharpoonright' => '8638', 'uplus' => '8846', 'UpperLeftArrow' => '8598', 'UpperRightArrow' => '8599', 'upsi' => '965', 'Upsi' => '978', 'UpTee' => '8869', 'UpTeeArrow' => '8613', 'upuparrows' => '8648', 'urcorn' => '8989', 'urcorner' => '8989', 'urcrop' => '8974', 'Uring' => '366', 'uring' => '367', 'urtri' => '9721', 'Uscr' => '119984', 'uscr' => '120010', 'utdot' => '8944', 'Utilde' => '360', 'utilde' => '361', 'utri' => '9653', 'utrif' => '9652', 'uuarr' => '8648', 'uwangle' => '10663', 'vangrt' => '10652', 'varepsilon' => '1013', 'varkappa' => '1008', 'varnothing' => '8709', 'varphi' => '981', 'varpi' => '982', 'varpropto' => '8733', 'varr' => '8597', 'vArr' => '8661', 'varrho' => '1009', 'varsigma' => '962', 'vartheta' => '977', 'vartriangleleft' => '8882', 'vartriangleright' => '8883', 'vBar' => '10984', 'Vbar' => '10987', 'vBarv' => '10985', 'Vcy' => '1042', 'vcy' => '1074', 'vdash' => '8866', 'vDash' => '8872', 'Vdash' => '8873', 'VDash' => '8875', 'Vdashl' => '10982', 'vee' => '8744', 'Vee' => '8897', 'veebar' => '8891', 'veeeq' => '8794', 'vellip' => '8942', 'verbar' => '124', 'Verbar' => '8214', 'vert' => '124', 'Vert' => '8214', 'VerticalBar' => '8739', 'VerticalLine' => '124', 'VerticalSeparator' => '10072', 'VerticalTilde' => '8768', 'VeryThinSpace' => '8202', 'Vfr' => '120089', 'vfr' => '120115', 'vltri' => '8882', 'Vopf' => '120141', 'vopf' => '120167', 'vprop' => '8733', 'vrtri' => '8883', 'Vscr' => '119985', 'vscr' => '120011', 'Vvdash' => '8874', 'vzigzag' => '10650', 'Wcirc' => '372', 'wcirc' => '373', 'wedbar' => '10847', 'wedge' => '8743', 'Wedge' => '8896', 'wedgeq' => '8793', 'Wfr' => '120090', 'wfr' => '120116', 'Wopf' => '120142', 'wopf' => '120168', 'wp' => '8472', 'wr' => '8768', 'wreath' => '8768', 'Wscr' => '119986', 'wscr' => '120012', 'xcap' => '8898', 'xcirc' => '9711', 'xcup' => '8899', 'xdtri' => '9661', 'Xfr' => '120091', 'xfr' => '120117', 'xharr' => '10231', 'xhArr' => '10234', 'xlarr' => '10229', 'xlArr' => '10232', 'xmap' => '10236', 'xnis' => '8955', 'xodot' => '10752', 'Xopf' => '120143', 'xopf' => '120169', 'xoplus' => '10753', 'xotime' => '10754', 'xrarr' => '10230', 'xrArr' => '10233', 'Xscr' => '119987', 'xscr' => '120013', 'xsqcup' => '10758', 'xuplus' => '10756', 'xutri' => '9651', 'xvee' => '8897', 'xwedge' => '8896', 'YAcy' => '1071', 'yacy' => '1103', 'Ycirc' => '374', 'ycirc' => '375', 'Ycy' => '1067', 'ycy' => '1099', 'Yfr' => '120092', 'yfr' => '120118', 'YIcy' => '1031', 'yicy' => '1111', 'Yopf' => '120144', 'yopf' => '120170', 'Yscr' => '119988', 'yscr' => '120014', 'YUcy' => '1070', 'yucy' => '1102', 'Zacute' => '377', 'zacute' => '378', 'Zcaron' => '381', 'zcaron' => '382', 'Zcy' => '1047', 'zcy' => '1079', 'Zdot' => '379', 'zdot' => '380', 'zeetrf' => '8488', 'ZeroWidthSpace' => '8203', 'zfr' => '120119', 'Zfr' => '8488', 'ZHcy' => '1046', 'zhcy' => '1078', 'zigrarr' => '8669', 'zopf' => '120171', 'Zopf' => '8484', 'Zscr' => '119989', 'zscr' => '120015'];
+    if ($t[0] != '#') {
         return
             ($C['and_mark'] ? "\x06" : '&')
             .(isset($reservedEntAr[$t])
@@ -833,14 +829,14 @@ function hl_entity(array $t): string
     if (
         ($n = ctype_digit($t = substr($t, 1)) ? intval($t) : hexdec(substr($t, 1))) < 9
         || ($n > 13 && $n < 32)
-        || 11 == $n
-        || 12 == $n
-        || ($n > 126 && $n < 160 && 133 != $n)
+        || $n == 11
+        || $n == 12
+        || ($n > 126 && $n < 160 && $n != 133)
         || ($n > 55295
             && ($n < 57344
                 || ($n > 64975 && $n < 64992)
-                || 65534 == $n
-                || 65535 == $n
+                || $n == 65534
+                || $n == 65535
                 || $n > 1114111))
     ) {
         return ($C['and_mark'] ? "\x06" : '&')."amp;#{$t};";
@@ -860,7 +856,6 @@ function hl_entity(array $t): string
  * Check regex pattern for PHP error.
  *
  * @param  string  $t  Pattern including limiters/modifiers.
- *
  * @return int 0 or 1 if pattern is invalid or valid, respectively.
  */
 function hl_regex(string $t): int
@@ -883,7 +878,7 @@ function hl_regex(string $t): int
     }
     preg_match($t, '');
     if ($funcsExist) {
-        $out = null == error_get_last() ? 1 : 0;
+        $out = error_get_last() == null ? 1 : 0;
     } else {
         $out = isset($php_errormsg) ? 0 : 1;
         if ($valTrackErr) {
@@ -903,7 +898,6 @@ function hl_regex(string $t): int
  * Parse $spec htmLawed argument as array.
  *
  * @param  string  $t  Value of $spec.
- *
  * @return array Multidimensional array of form: tag -> attribute -> rule.
  */
 function hl_spec(string $t): array
@@ -952,7 +946,7 @@ function hl_spec(string $t): array
 
                 continue;
             }
-            if ('-' == $attr[0]) {
+            if ($attr[0] == '-') {
                 $denyAttrAr[substr($attr, 1)] = 1;
 
                 continue;
@@ -971,8 +965,8 @@ function hl_spec(string $t): array
 
                     continue;
                 }
-                $rule                     = strtolower(substr($m, 0, $rulePos));
-                $ruleAr[$attr][$rule]     =
+                $rule = strtolower(substr($m, 0, $rulePos));
+                $ruleAr[$attr][$rule] =
                     str_replace(
                         ["\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07", "\x08"],
                         [';', '|', '~', ' ', ',', '/', '(', ')'],
@@ -1009,7 +1003,6 @@ function hl_spec(string $t): array
  * Handle tag text with </> limiters, and attributes in opening tags.
  *
  * @param  array  $t  Array from preg_replace call.
- *
  * @return string Tag with any attribute,
  *                or text with </> neutralized into entities, or empty.
  */
@@ -1020,10 +1013,10 @@ function hl_tag(array $t): string
 
     // Check if </> character not in tag.
 
-    if ('< ' == $t) {
+    if ($t == '< ') {
         return '&lt; ';
     }
-    if ('>' == $t) {
+    if ($t == '>') {
         return '&gt;';
     }
     if (! preg_match('`^<(/?)([a-zA-Z][^\s>]*)([^>]*?)\s?>$`m', $t, $m)) { // Get tag with element name and attributes
@@ -1032,7 +1025,7 @@ function hl_tag(array $t): string
 
     // Check if element not permitted. Custom element names have certain requirements.
 
-    $ele                       = rtrim(strtolower($m[2]), '/');
+    $ele = rtrim(strtolower($m[2]), '/');
     static $invalidCustomEleAr = ['annotation-xml' => 1, 'color-profile' => 1, 'font-face' => 1, 'font-face-src' => 1, 'font-face-uri' => 1, 'font-face-format' => 1, 'font-face-name' => 1, 'missing-glyph' => 1];
     if (
         (! strpos($ele, '-')
@@ -1112,59 +1105,59 @@ function hl_tag(array $t): string
 
     $alterDeprecAttr = 0;
     if ($C['no_deprecated_attr']) {
-        static $deprecAttrEleAr         = ['align' => ['caption' => 1, 'div' => 1, 'h1' => 1, 'h2' => 1, 'h3' => 1, 'h4' => 1, 'h5' => 1, 'h6' => 1, 'hr' => 1, 'img' => 1, 'input' => 1, 'legend' => 1, 'object' => 1, 'p' => 1, 'table' => 1], 'bgcolor' => ['table' => 1, 'tbody' => 1, 'td' => 1, 'tfoot' => 1, 'th' => 1, 'thead' => 1, 'tr' => 1], 'border' => ['object' => 1], 'bordercolor' => ['table' => 1, 'td' => 1, 'tr' => 1], 'cellspacing' => ['table' => 1], 'clear' => ['br' => 1], 'compact' => ['dl' => 1, 'ol' => 1, 'ul' => 1], 'height' => ['td' => 1, 'th' => 1], 'hspace' => ['img' => 1, 'object' => 1], 'language' => ['script' => 1], 'name' => ['a' => 1, 'form' => 1, 'iframe' => 1, 'img' => 1, 'map' => 1], 'noshade' => ['hr' => 1], 'nowrap' => ['td' => 1, 'th' => 1], 'size' => ['hr' => 1], 'vspace' => ['img' => 1, 'object' => 1], 'width' => ['hr' => 1, 'pre' => 1, 'table' => 1, 'td' => 1, 'th' => 1]];
+        static $deprecAttrEleAr = ['align' => ['caption' => 1, 'div' => 1, 'h1' => 1, 'h2' => 1, 'h3' => 1, 'h4' => 1, 'h5' => 1, 'h6' => 1, 'hr' => 1, 'img' => 1, 'input' => 1, 'legend' => 1, 'object' => 1, 'p' => 1, 'table' => 1], 'bgcolor' => ['table' => 1, 'tbody' => 1, 'td' => 1, 'tfoot' => 1, 'th' => 1, 'thead' => 1, 'tr' => 1], 'border' => ['object' => 1], 'bordercolor' => ['table' => 1, 'td' => 1, 'tr' => 1], 'cellspacing' => ['table' => 1], 'clear' => ['br' => 1], 'compact' => ['dl' => 1, 'ol' => 1, 'ul' => 1], 'height' => ['td' => 1, 'th' => 1], 'hspace' => ['img' => 1, 'object' => 1], 'language' => ['script' => 1], 'name' => ['a' => 1, 'form' => 1, 'iframe' => 1, 'img' => 1, 'map' => 1], 'noshade' => ['hr' => 1], 'nowrap' => ['td' => 1, 'th' => 1], 'size' => ['hr' => 1], 'vspace' => ['img' => 1, 'object' => 1], 'width' => ['hr' => 1, 'pre' => 1, 'table' => 1, 'td' => 1, 'th' => 1]];
         static $deprecAttrPossibleEleAr = ['a' => 1, 'br' => 1, 'caption' => 1, 'div' => 1, 'dl' => 1, 'form' => 1, 'h1' => 1, 'h2' => 1, 'h3' => 1, 'h4' => 1, 'h5' => 1, 'h6' => 1, 'hr' => 1, 'iframe' => 1, 'img' => 1, 'input' => 1, 'legend' => 1, 'map' => 1, 'object' => 1, 'ol' => 1, 'p' => 1, 'pre' => 1, 'script' => 1, 'table' => 1, 'td' => 1, 'th' => 1, 'tr' => 1, 'ul' => 1];
-        $alterDeprecAttr                = isset($deprecAttrPossibleEleAr[$ele]) ? 1 : 0;
+        $alterDeprecAttr = isset($deprecAttrPossibleEleAr[$ele]) ? 1 : 0;
     }
 
     // -- Standard attribute values that may need lowercasing.
 
     if ($C['lc_std_val']) {
-        static $lCaseStdAttrValAr            = ['all' => 1, 'auto' => 1, 'baseline' => 1, 'bottom' => 1, 'button' => 1, 'captions' => 1, 'center' => 1, 'chapters' => 1, 'char' => 1, 'checkbox' => 1, 'circle' => 1, 'col' => 1, 'colgroup' => 1, 'color' => 1, 'cols' => 1, 'data' => 1, 'date' => 1, 'datetime' => 1, 'datetime-local' => 1, 'default' => 1, 'descriptions' => 1, 'email' => 1, 'file' => 1, 'get' => 1, 'groups' => 1, 'hidden' => 1, 'image' => 1, 'justify' => 1, 'left' => 1, 'ltr' => 1, 'metadata' => 1, 'middle' => 1, 'month' => 1, 'none' => 1, 'number' => 1, 'object' => 1, 'password' => 1, 'poly' => 1, 'post' => 1, 'preserve' => 1, 'radio' => 1, 'range' => 1, 'rect' => 1, 'ref' => 1, 'reset' => 1, 'right' => 1, 'row' => 1, 'rowgroup' => 1, 'rows' => 1, 'rtl' => 1, 'search' => 1, 'submit' => 1, 'subtitles' => 1, 'tel' => 1, 'text' => 1, 'time' => 1, 'top' => 1, 'url' => 1, 'week' => 1];
+        static $lCaseStdAttrValAr = ['all' => 1, 'auto' => 1, 'baseline' => 1, 'bottom' => 1, 'button' => 1, 'captions' => 1, 'center' => 1, 'chapters' => 1, 'char' => 1, 'checkbox' => 1, 'circle' => 1, 'col' => 1, 'colgroup' => 1, 'color' => 1, 'cols' => 1, 'data' => 1, 'date' => 1, 'datetime' => 1, 'datetime-local' => 1, 'default' => 1, 'descriptions' => 1, 'email' => 1, 'file' => 1, 'get' => 1, 'groups' => 1, 'hidden' => 1, 'image' => 1, 'justify' => 1, 'left' => 1, 'ltr' => 1, 'metadata' => 1, 'middle' => 1, 'month' => 1, 'none' => 1, 'number' => 1, 'object' => 1, 'password' => 1, 'poly' => 1, 'post' => 1, 'preserve' => 1, 'radio' => 1, 'range' => 1, 'rect' => 1, 'ref' => 1, 'reset' => 1, 'right' => 1, 'row' => 1, 'rowgroup' => 1, 'rows' => 1, 'rtl' => 1, 'search' => 1, 'submit' => 1, 'subtitles' => 1, 'tel' => 1, 'text' => 1, 'time' => 1, 'top' => 1, 'url' => 1, 'week' => 1];
         static $lCaseStdAttrValPossibleEleAr = ['a' => 1, 'area' => 1, 'bdo' => 1, 'button' => 1, 'col' => 1, 'fieldset' => 1, 'form' => 1, 'img' => 1, 'input' => 1, 'object' => 1, 'ol' => 1, 'optgroup' => 1, 'option' => 1, 'param' => 1, 'script' => 1, 'select' => 1, 'table' => 1, 'td' => 1, 'textarea' => 1, 'tfoot' => 1, 'th' => 1, 'thead' => 1, 'tr' => 1, 'track' => 1, 'xml:space' => 1];
-        $lCaseStdAttrVal                     = isset($lCaseStdAttrValPossibleEleAr[$ele]) ? 1 : 0;
+        $lCaseStdAttrVal = isset($lCaseStdAttrValPossibleEleAr[$ele]) ? 1 : 0;
     }
 
     // -- Get attribute name-value pairs.
 
-    if (false !== strpos($attrStr, "\x01")) { // Remove CDATA/comment
+    if (strpos($attrStr, "\x01") !== false) { // Remove CDATA/comment
         $attrStr = preg_replace('`\x01[^\x01]*\x01`', '', $attrStr);
     }
     $attrStr = trim($attrStr, ' /');
-    $attrAr  = [];
-    $state   = 0;
+    $attrAr = [];
+    $state = 0;
     while (strlen($attrStr)) {
         $ok = 0; // For parsing errors, to deal with space, ", and ' characters
         switch ($state) {
             case 0:
                 if (preg_match('`^[^=\s/\x7f-\x9f]+`', $attrStr, $m)) { // Name
-                    $attr    = strtolower($m[0]);
-                    $ok      = $state = 1;
+                    $attr = strtolower($m[0]);
+                    $ok = $state = 1;
                     $attrStr = ltrim(substr_replace($attrStr, '', 0, strlen($m[0])));
                 }
                 break;
             case 1:
-                if ('=' == $attrStr[0]) {
-                    $ok      = 1;
-                    $state   = 2;
+                if ($attrStr[0] == '=') {
+                    $ok = 1;
+                    $state = 2;
                     $attrStr = ltrim($attrStr, '= ');
                 } else { // No value
-                    $ok              = 1;
-                    $state           = 0;
-                    $attrStr         = ltrim($attrStr);
-                    $attrAr[$attr]   = '';
+                    $ok = 1;
+                    $state = 0;
+                    $attrStr = ltrim($attrStr);
+                    $attrAr[$attr] = '';
                 }
                 break;
             case 2:
                 if (preg_match('`^((?:"[^"]*")|(?:\'[^\']*\')|(?:\s*[^\s"\']+))(.*)`', $attrStr, $m)) { // Value
-                    $attrStr         = ltrim($m[2]);
-                    $m               = $m[1];
-                    $ok              = 1;
-                    $state           = 0;
-                    $attrAr[$attr]   =
+                    $attrStr = ltrim($m[2]);
+                    $m = $m[1];
+                    $ok = 1;
+                    $state = 0;
+                    $attrAr[$attr] =
                         trim(
                             str_replace('<', '&lt;',
-                                ('"' == $m[0] || '\'' == $m[0])
+                                ($m[0] == '"' || $m[0] == '\'')
                                     ? substr($m, 1, -1)
                                     : $m));
                 }
@@ -1172,18 +1165,18 @@ function hl_tag(array $t): string
         }
         if (! $ok) {
             $attrStr = preg_replace('`^(?:"[^"]*("|$)|\'[^\']*(\'|$)|\S)*\s*`', '', $attrStr);
-            $state   = 0;
+            $state = 0;
         }
     }
-    if (1 == $state) {
+    if ($state == 1) {
         $attrAr[$attr] = '';
     }
 
     // -- Clean attributes.
 
     global $S;
-    $eleSpec      = isset($S[$ele]) ? $S[$ele] : [];
-    $filtAttrAr   = []; // Finalized attributes
+    $eleSpec = isset($S[$ele]) ? $S[$ele] : [];
+    $filtAttrAr = []; // Finalized attributes
     $deniedAttrAr = $C['deny_attribute'];
 
     foreach ($attrAr as $attr => $v) {
@@ -1198,7 +1191,7 @@ function hl_tag(array $t): string
                     || isset($globalAttrAr[$attr])
                     || preg_match('`data-((?!xml)[^:]+$)`', $attr)
                     || (strpos($ele, '-')
-                        && 0 !== strpos($attr, 'data-xml')))
+                        && strpos($attr, 'data-xml') !== 0))
 
                 // .... No denial through $spec.
 
@@ -1231,18 +1224,18 @@ function hl_tag(array $t): string
                 $v = $attr;
             } elseif (
                 ! empty($lCaseStdAttrVal)  // ! Rather loose but should be ok
-                && (('button' != $ele || 'input' != $ele)
-                    || 'type' == $attr)
+                && (($ele != 'button' || $ele != 'input')
+                    || $attr == 'type')
             ) {
                 $v = (isset($lCaseStdAttrValAr[($vNew = strtolower($v))])) ? $vNew : $v;
             }
 
             // .. URLs and CSS expressions in style attribute.
 
-            if ('style' == $attr && ! $C['style_pass']) {
-                if (false !== strpos($v, '&#')) { // Change any entity to character
+            if ($attr == 'style' && ! $C['style_pass']) {
+                if (strpos($v, '&#') !== false) { // Change any entity to character
                     static $entityAr = ['&#32;' => ' ', '&#x20;' => ' ', '&#58;' => ':', '&#x3a;' => ':', '&#34;' => '"', '&#x22;' => '"', '&#40;' => '(', '&#x28;' => '(', '&#41;' => ')', '&#x29;' => ')', '&#42;' => '*', '&#x2a;' => '*', '&#47;' => '/', '&#x2f;' => '/', '&#92;' => '\\', '&#x5c;' => '\\', '&#101;' => 'e', '&#69;' => 'e', '&#x45;' => 'e', '&#x65;' => 'e', '&#105;' => 'i', '&#73;' => 'i', '&#x49;' => 'i', '&#x69;' => 'i', '&#108;' => 'l', '&#76;' => 'l', '&#x4c;' => 'l', '&#x6c;' => 'l', '&#110;' => 'n', '&#78;' => 'n', '&#x4e;' => 'n', '&#x6e;' => 'n', '&#111;' => 'o', '&#79;' => 'o', '&#x4f;' => 'o', '&#x6f;' => 'o', '&#112;' => 'p', '&#80;' => 'p', '&#x50;' => 'p', '&#x70;' => 'p', '&#114;' => 'r', '&#82;' => 'r', '&#x52;' => 'r', '&#x72;' => 'r', '&#115;' => 's', '&#83;' => 's', '&#x53;' => 's', '&#x73;' => 's', '&#117;' => 'u', '&#85;' => 'u', '&#x55;' => 'u', '&#x75;' => 'u', '&#120;' => 'x', '&#88;' => 'x', '&#x58;' => 'x', '&#x78;' => 'x', '&#39;' => "'", '&#x27;' => "'"];
-                    $v               = strtr($v, $entityAr);
+                    $v = strtr($v, $entityAr);
                 }
                 $v =
                     preg_replace_callback(
@@ -1255,13 +1248,13 @@ function hl_tag(array $t): string
 
                 // .. URLs in other attributes.
 
-            } elseif (isset($urlAttrAr[$attr]) || (isset($globalAttrAr[$attr]) && 0 === strpos($attr, 'on'))) {
+            } elseif (isset($urlAttrAr[$attr]) || (isset($globalAttrAr[$attr]) && strpos($attr, 'on') === 0)) {
                 $v =
                     str_replace('­', ' ',
-                        (false !== strpos($v, '&')  // ! Double-quoted character = soft-hyphen
+                        (strpos($v, '&') !== false  // ! Double-quoted character = soft-hyphen
                             ? str_replace(['&#xad;', '&#173;', '&shy;'], ' ', $v)
                             : $v));
-                if ('srcset' == $attr || ('archive' == $attr && 'applet' == $ele)) {
+                if ($attr == 'srcset' || ($attr == 'archive' && $ele == 'applet')) {
                     $vNew = '';
                     foreach (explode(',', $v) as $k => $x) {
                         $x = explode(' ', ltrim($x), 2);
@@ -1273,7 +1266,7 @@ function hl_tag(array $t): string
                     }
                     $v = trim($vNew, ', ');
                 }
-                if ('itemtype' == $attr || ('archive' == $attr && 'object' == $ele)) {
+                if ($attr == 'itemtype' || ($attr == 'archive' && $ele == 'object')) {
                     $vNew = '';
                     foreach (explode(' ', $v) as $x) {
                         if (isset($x[0])) {
@@ -1287,8 +1280,8 @@ function hl_tag(array $t): string
 
                 // Anti-spam measure.
 
-                if ('href' == $attr) {
-                    if ($C['anti_mail_spam'] && 0 === strpos($v, 'mailto:')) {
+                if ($attr == 'href') {
+                    if ($C['anti_mail_spam'] && strpos($v, 'mailto:') === 0) {
                         $v = str_replace('@', htmlspecialchars($C['anti_mail_spam']), $v);
                     } elseif ($C['anti_link_spam']) {
                         $x = $C['anti_link_spam'][1];
@@ -1347,74 +1340,74 @@ function hl_tag(array $t): string
     if ($alterDeprecAttr) {
         $css = [];
         foreach ($filtAttrAr as $name => $val) {
-            if ('style' == $name || ! isset($deprecAttrEleAr[$name][$ele])) {
+            if ($name == 'style' || ! isset($deprecAttrEleAr[$name][$ele])) {
                 continue;
             }
             $val = str_replace(['\\', ':', ';', '&#'], '', $val);
-            if ('align' == $name) {
+            if ($name == 'align') {
                 unset($filtAttrAr['align']);
-                if ('img' == $ele && ('left' == $val || 'right' == $val)) {
+                if ($ele == 'img' && ($val == 'left' || $val == 'right')) {
                     $css[] = 'float: '.$val;
-                } elseif (('div' == $ele || 'table' == $ele) && 'center' == $val) {
+                } elseif (($ele == 'div' || $ele == 'table') && $val == 'center') {
                     $css[] = 'margin: auto';
                 } else {
                     $css[] = 'text-align: '.$val;
                 }
-            } elseif ('bgcolor' == $name) {
+            } elseif ($name == 'bgcolor') {
                 unset($filtAttrAr['bgcolor']);
                 $css[] = 'background-color: '.$val;
-            } elseif ('border' == $name) {
+            } elseif ($name == 'border') {
                 unset($filtAttrAr['border']);
                 $css[] = "border: {$val}px";
-            } elseif ('bordercolor' == $name) {
+            } elseif ($name == 'bordercolor') {
                 unset($filtAttrAr['bordercolor']);
                 $css[] = 'border-color: '.$val;
-            } elseif ('cellspacing' == $name) {
+            } elseif ($name == 'cellspacing') {
                 unset($filtAttrAr['cellspacing']);
                 $css[] = "border-spacing: {$val}px";
-            } elseif ('clear' == $name) {
+            } elseif ($name == 'clear') {
                 unset($filtAttrAr['clear']);
-                $css[] = 'clear: '.('all' != $val ? $val : 'both');
-            } elseif ('compact' == $name) {
+                $css[] = 'clear: '.($val != 'all' ? $val : 'both');
+            } elseif ($name == 'compact') {
                 unset($filtAttrAr['compact']);
                 $css[] = 'font-size: 85%';
-            } elseif ('height' == $name || 'width' == $name) {
+            } elseif ($name == 'height' || $name == 'width') {
                 unset($filtAttrAr[$name]);
                 $css[] =
                     $name
                     .': '
-                    .((isset($val[0]) && '*' != $val[0])
+                    .((isset($val[0]) && $val[0] != '*')
                         ? $val.(ctype_digit($val) ? 'px' : '')
                         : 'auto');
-            } elseif ('hspace' == $name) {
+            } elseif ($name == 'hspace') {
                 unset($filtAttrAr['hspace']);
                 $css[] = "margin-left: {$val}px; margin-right: {$val}px";
-            } elseif ('language' == $name && ! isset($filtAttrAr['type'])) {
+            } elseif ($name == 'language' && ! isset($filtAttrAr['type'])) {
                 unset($filtAttrAr['language']);
                 $filtAttrAr['type'] = 'text/'.strtolower($val);
-            } elseif ('name' == $name) {
-                if (2 == $C['no_deprecated_attr'] || ('a' != $ele && 'map' != $ele)) {
+            } elseif ($name == 'name') {
+                if ($C['no_deprecated_attr'] == 2 || ($ele != 'a' && $ele != 'map')) {
                     unset($filtAttrAr['name']);
                 }
                 if (! isset($filtAttrAr['id']) && ! preg_match('`\W`', $val)) {
                     $filtAttrAr['id'] = $val;
                 }
-            } elseif ('noshade' == $name) {
+            } elseif ($name == 'noshade') {
                 unset($filtAttrAr['noshade']);
                 $css[] = 'border-style: none; border: 0; background-color: gray; color: gray';
-            } elseif ('nowrap' == $name) {
+            } elseif ($name == 'nowrap') {
                 unset($filtAttrAr['nowrap']);
                 $css[] = 'white-space: nowrap';
-            } elseif ('size' == $name) {
+            } elseif ($name == 'size') {
                 unset($filtAttrAr['size']);
                 $css[] = 'size: '.$val.'px';
-            } elseif ('vspace' == $name) {
+            } elseif ($name == 'vspace') {
                 unset($filtAttrAr['vspace']);
                 $css[] = "margin-top: {$val}px; margin-bottom: {$val}px";
             }
         }
         if (count($css)) {
-            $css                 = implode('; ', $css);
+            $css = implode('; ', $css);
             $filtAttrAr['style'] =
                 isset($filtAttrAr['style'])
                     ? rtrim($filtAttrAr['style'], ' ;').'; '.$css.';'
@@ -1425,7 +1418,7 @@ function hl_tag(array $t): string
     // -- Enforce unique id attribute values.
 
     if ($C['unique_ids'] && isset($filtAttrAr['id'])) {
-        if (preg_match('`\s`', ($id = $filtAttrAr['id'])) || (isset($GLOBALS['hl_Ids'][$id]) && 1 == $C['unique_ids'])) {
+        if (preg_match('`\s`', ($id = $filtAttrAr['id'])) || (isset($GLOBALS['hl_Ids'][$id]) && $C['unique_ids'] == 1)) {
             unset($filtAttrAr['id']);
         } else {
             while (isset($GLOBALS['hl_Ids'][$id])) {
@@ -1439,7 +1432,7 @@ function hl_tag(array $t): string
 
     if ($C['xml:lang'] && isset($filtAttrAr['lang'])) {
         $filtAttrAr['xml:lang'] = isset($filtAttrAr['xml:lang']) ? $filtAttrAr['xml:lang'] : $filtAttrAr['lang'];
-        if (2 == $C['xml:lang']) {
+        if ($C['xml:lang'] == 2) {
             unset($filtAttrAr['lang']);
         }
     }
@@ -1474,7 +1467,6 @@ function hl_tag(array $t): string
  * @param  string  $t  HTM.
  * @param  mixed  $format  -1 (compact) or string (type of padding).
  * @param  string  $parentEle  Parent element of $t.
- *
  * @return mixed Transformed attribute string (may be empty) or 0.
  */
 function hl_tidy(string $t, mixed $format, string $parentEle): mixed
@@ -1510,23 +1502,23 @@ function hl_tidy(string $t, mixed $format, string $parentEle): mixed
         return str_replace(["\x01", "\x02", "\x03", "\x04", "\x05", "\x07"], ['<', '>', "\n", "\r", "\t", ' '], $t);
     }
     $padChar = strpos(" $format", 't') ? "\t" : ' ';
-    $padStr  =
+    $padStr =
         preg_match('`\d`', $format, $m)
             ? str_repeat($padChar, intval($m[0]))
-            : str_repeat($padChar, ("\t" == $padChar ? 1 : 2));
-    $leadN   = preg_match('`[ts]([1-9])`', $format, $m) ? intval($m[1]) : 0;
+            : str_repeat($padChar, ($padChar == "\t" ? 1 : 2));
+    $leadN = preg_match('`[ts]([1-9])`', $format, $m) ? intval($m[1]) : 0;
 
     // Group elements by line-break requirement.
 
-    $postCloseEleAr        = ['br' => 1]; // After closing
-    $preEleAr              = ['button' => 1, 'command' => 1, 'input' => 1, 'option' => 1, 'param' => 1, 'track' => 1]; // Before opening or closing
+    $postCloseEleAr = ['br' => 1]; // After closing
+    $preEleAr = ['button' => 1, 'command' => 1, 'input' => 1, 'option' => 1, 'param' => 1, 'track' => 1]; // Before opening or closing
     $preOpenPostCloseEleAr = ['audio' => 1, 'canvas' => 1, 'caption' => 1, 'dd' => 1, 'dt' => 1, 'figcaption' => 1, 'h1' => 1, 'h2' => 1, 'h3' => 1, 'h4' => 1, 'h5' => 1, 'h6' => 1, 'isindex' => 1, 'label' => 1, 'legend' => 1, 'li' => 1, 'object' => 1, 'p' => 1, 'pre' => 1, 'style' => 1, 'summary' => 1, 'td' => 1, 'textarea' => 1, 'th' => 1, 'video' => 1]; // Before opening and after closing
-    $prePostEleAr          = ['address' => 1, 'article' => 1, 'aside' => 1, 'blockquote' => 1, 'center' => 1, 'colgroup' => 1, 'datalist' => 1, 'details' => 1, 'dialog' => 1, 'dir' => 1, 'div' => 1, 'dl' => 1, 'fieldset' => 1, 'figure' => 1, 'footer' => 1, 'form' => 1, 'header' => 1, 'hgroup' => 1, 'hr' => 1, 'iframe' => 1, 'main' => 1, 'map' => 1, 'menu' => 1, 'nav' => 1, 'noscript' => 1, 'ol' => 1, 'optgroup' => 1, 'picture' => 1, 'rbc' => 1, 'rtc' => 1, 'ruby' => 1, 'script' => 1, 'section' => 1, 'select' => 1, 'table' => 1, 'tbody' => 1, 'template' => 1, 'tfoot' => 1, 'thead' => 1, 'tr' => 1, 'ul' => 1]; // Before and after opening and closing
+    $prePostEleAr = ['address' => 1, 'article' => 1, 'aside' => 1, 'blockquote' => 1, 'center' => 1, 'colgroup' => 1, 'datalist' => 1, 'details' => 1, 'dialog' => 1, 'dir' => 1, 'div' => 1, 'dl' => 1, 'fieldset' => 1, 'figure' => 1, 'footer' => 1, 'form' => 1, 'header' => 1, 'hgroup' => 1, 'hr' => 1, 'iframe' => 1, 'main' => 1, 'map' => 1, 'menu' => 1, 'nav' => 1, 'noscript' => 1, 'ol' => 1, 'optgroup' => 1, 'picture' => 1, 'rbc' => 1, 'rtc' => 1, 'ruby' => 1, 'script' => 1, 'section' => 1, 'select' => 1, 'table' => 1, 'tbody' => 1, 'template' => 1, 'tfoot' => 1, 'thead' => 1, 'tr' => 1, 'ul' => 1]; // Before and after opening and closing
 
     $doPad = 1;
-    $t     = explode('<', $t);
+    $t = explode('<', $t);
     while ($doPad) {
-        $n     = $leadN;
+        $n = $leadN;
         $eleAr = $t;
         ob_start();
         if (isset($prePostEleAr[$parentEle])) {
@@ -1534,11 +1526,11 @@ function hl_tidy(string $t, mixed $format, string $parentEle): mixed
         }
         echo ltrim(array_shift($eleAr));
         for ($i = -1, $j = count($eleAr); ++$i < $j;) {
-            $rest         = '';
+            $rest = '';
             [$tag, $rest] = explode('>', $eleAr[$i]);
-            $open         = '/' == $tag[0] ? 0 : ('/' == substr($tag, -1) ? 1 : ('!' != $tag[0] ? 2 : -1));
-            $ele          = ! $open ? ltrim($tag, '/') : ($open > 0 ? substr($tag, 0, strcspn($tag, ' ')) : 0);
-            $tag          = "<$tag>";
+            $open = $tag[0] == '/' ? 0 : (substr($tag, -1) == '/' ? 1 : ($tag[0] != '!' ? 2 : -1));
+            $ele = ! $open ? ltrim($tag, '/') : ($open > 0 ? substr($tag, 0, strcspn($tag, ' ')) : 0);
+            $tag = "<$tag>";
             if (isset($prePostEleAr[$ele])) {
                 if (! $open) {
                     if ($n) {
@@ -1550,7 +1542,7 @@ function hl_tidy(string $t, mixed $format, string $parentEle): mixed
                         continue 2;
                     }
                 } else {
-                    echo "\n", str_repeat($padStr, $n), "$tag\n", str_repeat($padStr, (1 != $open ? ++$n : $n));
+                    echo "\n", str_repeat($padStr, $n), "$tag\n", str_repeat($padStr, ($open != 1 ? ++$n : $n));
                 }
                 echo $rest;
 
@@ -1590,19 +1582,18 @@ function hl_tidy(string $t, mixed $format, string $parentEle): mixed
  *
  * @param  mixed  $url  URL string, or array with URL value (if $attr is null).
  * @param  mixed  $attr  Attribute name string, or null (if $url is array).
- *
  * @return string With URL after any conversion/obfuscation.
  */
 function hl_url(mixed $url, mixed $attr = null): string
 {
     global $C;
-    $preUrl         = $postUrl = '';
+    $preUrl = $postUrl = '';
     static $blocker = 'denied:';
-    if (null == $attr) { // style attribute value
-        $attr    = 'style';
-        $preUrl  = $url[1];
+    if ($attr == null) { // style attribute value
+        $attr = 'style';
+        $preUrl = $url[1];
         $postUrl = $url[3];
-        $url     = trim($url[2]);
+        $url = trim($url[2]);
     }
     $okSchemeAr = isset($C['schemes'][$attr]) ? $C['schemes'][$attr] : $C['schemes']['*'];
     if (isset($okSchemeAr['!']) && substr($url, 0, 7) != $blocker) {
@@ -1620,12 +1611,12 @@ function hl_url(mixed $url, mixed $attr = null): string
         return "{$preUrl}{$blocker}{$url}{$postUrl}";
     }
     if ($C['abs_url']) {
-        if (-1 == $C['abs_url'] && 0 === strpos($url, $C['base_url'])) { // Make URL relative
+        if ($C['abs_url'] == -1 && strpos($url, $C['base_url']) === 0) { // Make URL relative
             $url = substr($url, strlen($C['base_url']));
         } elseif (empty($m[1])) { // Make URL absolute
-            if ('//' == substr($url, 0, 2)) {
+            if (substr($url, 0, 2) == '//') {
                 $url = HTMLawed.phpsubstr($C['base_url'], 0, strpos($C['base_url'], ':') + 1).$url;
-            } elseif ('/' == $url[0]) {
+            } elseif ($url[0] == '/') {
                 $url = HTMLawed.phppreg_replace('`(^.+?://[^/]+)(.*)`', '$1', $C['base_url']).$url;
             } elseif (strcspn($url, './')) {
                 $url = $C['base_url'].$url;

--- a/src/Http/Middleware/ApiRateLimiting.php
+++ b/src/Http/Middleware/ApiRateLimiting.php
@@ -34,40 +34,40 @@ class ApiRateLimiting
             return $next($request);
         }
 
-        $user  = $request->user();
+        $user = $request->user();
         $token = $user?->currentAccessToken();
 
         if ($user && $token) {
             // Authenticated request - use higher limits
             $config = config('artisanpack.security.api.rate_limiting.authenticated', [
-                'max_attempts'  => 60,
+                'max_attempts' => 60,
                 'decay_minutes' => 1,
             ]);
             $key = 'api_auth_'.$user->id.'_'.$token->id;
         } else {
             // Guest request - use lower limits
             $config = config('artisanpack.security.api.rate_limiting.guest', [
-                'max_attempts'  => 30,
+                'max_attempts' => 30,
                 'decay_minutes' => 1,
             ]);
             $key = 'api_guest_'.$request->ip();
         }
 
-        $maxAttempts  = $config['max_attempts'] ?? 60;
+        $maxAttempts = $config['max_attempts'] ?? 60;
         $decayMinutes = $config['decay_minutes'] ?? 1;
 
         if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
             $retryAfter = RateLimiter::availableIn($key);
 
             return response()->json([
-                'message'     => 'Too many requests. Please try again later.',
-                'error'       => 'rate_limit_exceeded',
+                'message' => 'Too many requests. Please try again later.',
+                'error' => 'rate_limit_exceeded',
                 'retry_after' => $retryAfter,
             ], 429)->withHeaders([
-                'Retry-After'           => $retryAfter,
-                'X-RateLimit-Limit'     => $maxAttempts,
+                'Retry-After' => $retryAfter,
+                'X-RateLimit-Limit' => $maxAttempts,
                 'X-RateLimit-Remaining' => 0,
-                'X-RateLimit-Reset'     => now()->addSeconds($retryAfter)->timestamp,
+                'X-RateLimit-Reset' => now()->addSeconds($retryAfter)->timestamp,
             ]);
         }
 

--- a/src/Http/Middleware/ApiSecurity.php
+++ b/src/Http/Middleware/ApiSecurity.php
@@ -38,7 +38,7 @@ class ApiSecurity
             if ($token->is_revoked ?? false) {
                 return response()->json([
                     'message' => 'Token has been revoked.',
-                    'error'   => 'token_revoked',
+                    'error' => 'token_revoked',
                 ], 401);
             }
 
@@ -46,7 +46,7 @@ class ApiSecurity
             if ($token->expires_at && $token->expires_at->isPast()) {
                 return response()->json([
                     'message' => 'Token has expired.',
-                    'error'   => 'token_expired',
+                    'error' => 'token_expired',
                 ], 401);
             }
 

--- a/src/Http/Middleware/ContentSecurityPolicy.php
+++ b/src/Http/Middleware/ContentSecurityPolicy.php
@@ -44,7 +44,7 @@ class ContentSecurityPolicy
         $this->csp->forRequest($request);
 
         // Apply preset if specified via middleware parameter
-        if (null !== $preset) {
+        if ($preset !== null) {
             $this->csp->usePreset($preset);
         }
 

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -27,7 +27,7 @@ class SecurityHeadersMiddleware
         $headers = config('artisanpack.security.security-headers', []);
 
         foreach ($headers as $key => $value) {
-            if (null !== $value && '' !== $value) {
+            if ($value !== null && $value !== '') {
                 $response->headers->set($key, $value);
             }
         }

--- a/src/Http/Requests/BaseFormRequest.php
+++ b/src/Http/Requests/BaseFormRequest.php
@@ -44,7 +44,7 @@ class BaseFormRequest extends FormRequest
     {
         foreach ($data as $key => &$value) {
             if (is_string($value)) {
-                $rule  = $this->sanitizationRules[$key] ?? 'text';
+                $rule = $this->sanitizationRules[$key] ?? 'text';
                 $value = $this->applySanitizationRule($rule, $value);
             }
         }
@@ -58,12 +58,12 @@ class BaseFormRequest extends FormRequest
     protected function applySanitizationRule(string $rule, string $value): string
     {
         return match ($rule) {
-            'html'     => kses($value),
-            'email'    => sanitizeEmail($value),
-            'url'      => sanitizeUrl($value),
+            'html' => kses($value),
+            'email' => sanitizeEmail($value),
+            'url' => sanitizeUrl($value),
             'filename' => sanitizeFilename($value),
-            'text'     => sanitizeText($value),
-            default    => $this->handleUnknownRule($rule, $value),
+            'text' => sanitizeText($value),
+            default => $this->handleUnknownRule($rule, $value),
         };
     }
 

--- a/src/Livewire/CspDashboard.php
+++ b/src/Livewire/CspDashboard.php
@@ -70,7 +70,7 @@ class CspDashboard extends Component
         $hours = $this->days * 24;
 
         // Summary stats
-        $this->totalViolations  = CspViolationReport::getTotalCount($hours);
+        $this->totalViolations = CspViolationReport::getTotalCount($hours);
         $this->uniqueViolations = CspViolationReport::getUniqueCount($hours);
 
         // Count by disposition
@@ -85,11 +85,11 @@ class CspDashboard extends Component
             ->sum('occurrence_count');
 
         // Chart: Violations by directive
-        $byDirective                      = CspViolationReport::getViolationsByDirective();
+        $byDirective = CspViolationReport::getViolationsByDirective();
         $this->violationsByDirectiveChart = $this->buildDirectiveChart($byDirective->toArray());
 
         // Chart: Trend over time
-        $trend                     = CspViolationReport::getViolationTrend($this->days);
+        $trend = CspViolationReport::getViolationTrend($this->days);
         $this->violationTrendChart = $this->buildTrendChart($trend);
 
         // Top blocked URIs
@@ -109,12 +109,12 @@ class CspDashboard extends Component
             ->limit(5)
             ->get()
             ->map(fn ($violation) => [
-                'directive'   => $violation->violated_directive,
+                'directive' => $violation->violated_directive,
                 'blocked_uri' => $violation->blocked_uri
                     ? (strlen($violation->blocked_uri) > 30 ? substr($violation->blocked_uri, 0, 27).'...' : $violation->blocked_uri)
                     : 'N/A',
                 'occurrence_count' => $violation->occurrence_count,
-                'last_seen'        => $violation->last_seen_at?->diffForHumans() ?? 'N/A',
+                'last_seen' => $violation->last_seen_at?->diffForHumans() ?? 'N/A',
             ])
             ->toArray();
     }
@@ -140,16 +140,16 @@ class CspDashboard extends Component
         return [
             'type' => 'doughnut',
             'data' => [
-                'labels'   => array_keys($data),
+                'labels' => array_keys($data),
                 'datasets' => [
                     [
-                        'data'            => array_values($data),
+                        'data' => array_values($data),
                         'backgroundColor' => array_slice($colors, 0, count($data)),
                     ],
                 ],
             ],
             'options' => [
-                'responsive'          => true,
+                'responsive' => true,
                 'maintainAspectRatio' => false,
             ],
         ];
@@ -169,22 +169,22 @@ class CspDashboard extends Component
         return [
             'type' => 'line',
             'data' => [
-                'labels'   => $labels,
+                'labels' => $labels,
                 'datasets' => [
                     [
-                        'label'           => 'Violations',
-                        'data'            => array_values($data),
-                        'borderColor'     => 'rgba(239, 68, 68, 1)',
+                        'label' => 'Violations',
+                        'data' => array_values($data),
+                        'borderColor' => 'rgba(239, 68, 68, 1)',
                         'backgroundColor' => 'rgba(239, 68, 68, 0.1)',
-                        'fill'            => true,
-                        'tension'         => 0.3,
+                        'fill' => true,
+                        'tension' => 0.3,
                     ],
                 ],
             ],
             'options' => [
-                'responsive'          => true,
+                'responsive' => true,
                 'maintainAspectRatio' => false,
-                'scales'              => [
+                'scales' => [
                     'y' => [
                         'beginAtZero' => true,
                     ],

--- a/src/Models/CspViolationReport.php
+++ b/src/Models/CspViolationReport.php
@@ -52,11 +52,11 @@ class CspViolationReport extends Model
      * The attributes that should be cast.
      */
     protected $casts = [
-        'line_number'      => 'integer',
-        'column_number'    => 'integer',
+        'line_number' => 'integer',
+        'column_number' => 'integer',
         'occurrence_count' => 'integer',
-        'first_seen_at'    => 'datetime',
-        'last_seen_at'     => 'datetime',
+        'first_seen_at' => 'datetime',
+        'last_seen_at' => 'datetime',
     ];
 
     /**
@@ -123,12 +123,12 @@ class CspViolationReport extends Model
      */
     public static function getViolationTrend(int $days = 7): array
     {
-        $trend     = [];
+        $trend = [];
         $startDate = now()->subDays($days)->startOfDay();
 
         // Pre-fill with zeros for all dates in range
         for ($i = 0; $i <= $days; $i++) {
-            $date                          = $startDate->copy()->addDays($i);
+            $date = $startDate->copy()->addDays($i);
             $trend[$date->format('Y-m-d')] = 0;
         }
 

--- a/src/Rules/NoHtml.php
+++ b/src/Rules/NoHtml.php
@@ -22,7 +22,6 @@ class NoHtml implements Rule
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     *
      * @return bool
      */
     public function passes($attribute, $value)

--- a/src/Rules/SecureUrl.php
+++ b/src/Rules/SecureUrl.php
@@ -22,7 +22,6 @@ class SecureUrl implements Rule
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     *
      * @return bool
      */
     public function passes($attribute, $value)
@@ -31,7 +30,7 @@ class SecureUrl implements Rule
             return false;
         }
 
-        if (false === filter_var($value, FILTER_VALIDATE_URL)) {
+        if (filter_var($value, FILTER_VALIDATE_URL) === false) {
             return false;
         }
 

--- a/src/Security.php
+++ b/src/Security.php
@@ -28,7 +28,7 @@ class Security
      */
     public function sanitizeEmail(?string $email = ''): string
     {
-        if (null === $email || '' === $email) {
+        if ($email === null || $email === '') {
             return '';
         }
 
@@ -44,7 +44,7 @@ class Security
      */
     public function sanitizeUrl(?string $url = ''): string
     {
-        if (null === $url || '' === $url) {
+        if ($url === null || $url === '') {
             return '';
         }
 
@@ -60,7 +60,7 @@ class Security
      */
     public function sanitizeFilename(?string $filename = ''): string
     {
-        if (null === $filename || '' === $filename) {
+        if ($filename === null || $filename === '') {
             return '';
         }
 
@@ -76,7 +76,7 @@ class Security
      */
     public function sanitizePassword(?string $password = ''): string
     {
-        if (null === $password || '' === $password) {
+        if ($password === null || $password === '') {
             return '';
         }
 
@@ -104,7 +104,7 @@ class Security
      */
     public function sanitizeDate(?string $date = ''): string
     {
-        if (null === $date || '' === $date) {
+        if ($date === null || $date === '') {
             return '';
         }
 
@@ -160,7 +160,7 @@ class Security
      */
     public function sanitizeText(?string $input = ''): string
     {
-        if (null === $input || '' === $input) {
+        if ($input === null || $input === '') {
             return '';
         }
 
@@ -176,7 +176,7 @@ class Security
      */
     public function escHtml(?string $string = ''): string
     {
-        if (null === $string || '' === $string) {
+        if ($string === null || $string === '') {
             return '';
         }
 
@@ -192,7 +192,7 @@ class Security
      */
     public function escAttr(?string $string = ''): string
     {
-        if (null === $string || '' === $string) {
+        if ($string === null || $string === '') {
             return '';
         }
 
@@ -208,7 +208,7 @@ class Security
      */
     public function escUrl(?string $string = ''): string
     {
-        if (null === $string || '' === $string) {
+        if ($string === null || $string === '') {
             return '';
         }
 
@@ -224,7 +224,7 @@ class Security
      */
     public function escJs(?string $string = ''): string
     {
-        if (null === $string || '' === $string) {
+        if ($string === null || $string === '') {
             return '';
         }
 
@@ -240,7 +240,7 @@ class Security
      */
     public function escCss(?string $string = ''): string
     {
-        if (null === $string || '' === $string) {
+        if ($string === null || $string === '') {
             return '';
         }
 
@@ -268,7 +268,7 @@ class Security
     {
         foreach ($data as $key => &$value) {
             if (is_string($value)) {
-                $rule  = $rules[$key] ?? 'text';
+                $rule = $rules[$key] ?? 'text';
                 $value = $this->applySanitizationRule($rule, $value);
             }
         }
@@ -282,12 +282,12 @@ class Security
     protected function applySanitizationRule(string $rule, string $value): string
     {
         return match ($rule) {
-            'html'     => $this->kses($value),
-            'email'    => $this->sanitizeEmail($value),
-            'url'      => $this->sanitizeUrl($value),
+            'html' => $this->kses($value),
+            'email' => $this->sanitizeEmail($value),
+            'url' => $this->sanitizeUrl($value),
             'filename' => $this->sanitizeFilename($value),
-            'text'     => $this->sanitizeText($value),
-            default    => $this->sanitizeText($value),
+            'text' => $this->sanitizeText($value),
+            default => $this->sanitizeText($value),
         };
     }
 }

--- a/src/SecurityServiceProvider.php
+++ b/src/SecurityServiceProvider.php
@@ -31,6 +31,7 @@ use ArtisanPackUI\Security\Http\Middleware\ApiSecurity;
 use ArtisanPackUI\Security\Http\Middleware\ContentSecurityPolicy;
 use ArtisanPackUI\Security\Http\Middleware\SecurityHeadersMiddleware;
 use ArtisanPackUI\Security\Http\Middleware\XssProtection;
+use ArtisanPackUI\Security\Livewire\CspDashboard;
 use ArtisanPackUI\Security\Services\Csp\CspNonceGenerator;
 use ArtisanPackUI\Security\Services\Csp\CspPolicyService;
 use ArtisanPackUI\Security\Services\Csp\CspViolationHandler;
@@ -170,7 +171,7 @@ class SecurityServiceProvider extends ServiceProvider
         }
 
         foreach ((array) config('artisanpack.security.rateLimiting.limiters', []) as $name => $config) {
-            $maxAttempts  = (int) ($config['maxAttempts'] ?? 60);
+            $maxAttempts = (int) ($config['maxAttempts'] ?? 60);
             $decayMinutes = (int) ($config['decayMinutes'] ?? 1);
 
             RateLimiter::for($name, function (Request $request) use ($maxAttempts, $decayMinutes) {
@@ -202,6 +203,6 @@ class SecurityServiceProvider extends ServiceProvider
             return;
         }
 
-        Livewire::component('csp-dashboard', \ArtisanPackUI\Security\Livewire\CspDashboard::class);
+        Livewire::component('csp-dashboard', CspDashboard::class);
     }
 }

--- a/src/Services/Csp/CspNonceGenerator.php
+++ b/src/Services/Csp/CspNonceGenerator.php
@@ -38,7 +38,7 @@ class CspNonceGenerator
      */
     public function generate(): string
     {
-        if (null === $this->nonce) {
+        if ($this->nonce === null) {
             $this->nonce = base64_encode(random_bytes($this->length));
         }
 
@@ -58,7 +58,7 @@ class CspNonceGenerator
      */
     public function hasNonce(): bool
     {
-        return null !== $this->nonce;
+        return $this->nonce !== null;
     }
 
     /**

--- a/src/Services/Csp/CspPolicyBuilder.php
+++ b/src/Services/Csp/CspPolicyBuilder.php
@@ -426,7 +426,7 @@ class CspPolicyBuilder
         $parts = [];
 
         foreach ($this->directives as $directive => $values) {
-            if (true === $values) {
+            if ($values === true) {
                 $parts[] = $directive;
             } elseif (is_array($values) && ! empty($values)) {
                 $parts[] = $directive.' '.implode(' ', $values);

--- a/src/Services/Csp/CspPolicyService.php
+++ b/src/Services/Csp/CspPolicyService.php
@@ -178,7 +178,7 @@ class CspPolicyService implements CspPolicyInterface
      */
     public function toHeader(): array
     {
-        $policy  = $this->getPolicy();
+        $policy = $this->getPolicy();
         $headers = [];
 
         if (empty($policy)) {
@@ -220,7 +220,7 @@ class CspPolicyService implements CspPolicyInterface
     {
         $this->builder->reset();
         $this->nonceGenerator->reset();
-        $this->isBuilt       = false;
+        $this->isBuilt = false;
         $this->currentPreset = null;
 
         return $this;
@@ -275,8 +275,8 @@ class CspPolicyService implements CspPolicyInterface
     {
         $this->presets = [
             'livewire' => new LivewirePreset,
-            'strict'   => new StrictPreset,
-            'relaxed'  => new RelaxedPreset,
+            'strict' => new StrictPreset,
+            'relaxed' => new RelaxedPreset,
         ];
     }
 
@@ -286,7 +286,7 @@ class CspPolicyService implements CspPolicyInterface
     protected function determinePreset(Request $request): string
     {
         $routePolicies = config('artisanpack.security.csp.routePolicies', []);
-        $path          = $request->path();
+        $path = $request->path();
 
         foreach ($routePolicies as $pattern => $preset) {
             if ($this->matchesPattern($path, $pattern)) {
@@ -313,7 +313,7 @@ class CspPolicyService implements CspPolicyInterface
     protected function isExcludedRoute(Request $request): bool
     {
         $excludedRoutes = config('artisanpack.security.csp.excludedRoutes', []);
-        $path           = $request->path();
+        $path = $request->path();
 
         foreach ($excludedRoutes as $pattern) {
             if ($this->matchesPattern($path, $pattern)) {

--- a/src/Services/Csp/CspViolationHandler.php
+++ b/src/Services/Csp/CspViolationHandler.php
@@ -67,16 +67,16 @@ class CspViolationHandler
         if ($violation) {
             // Update existing violation
             $violation->update([
-                'last_seen_at'     => now(),
+                'last_seen_at' => now(),
                 'occurrence_count' => $violation->occurrence_count + 1,
             ]);
         } else {
             // Create new violation record
             $violation = CspViolationReport::create(array_merge($data, [
-                'fingerprint'      => $fingerprint,
+                'fingerprint' => $fingerprint,
                 'occurrence_count' => 1,
-                'first_seen_at'    => now(),
-                'last_seen_at'     => now(),
+                'first_seen_at' => now(),
+                'last_seen_at' => now(),
             ]));
         }
 
@@ -105,33 +105,32 @@ class CspViolationHandler
             ?? $report['effectiveDirective']
             ?? null;
 
-        return null !== $directive;
+        return $directive !== null;
     }
 
     /**
      * Normalize report data from different CSP report formats.
      *
      * @param  array<string, mixed>  $report
-     *
      * @return array<string, mixed>
      */
     protected function normalizeReport(array $report): array
     {
         return [
-            'document_uri'        => $this->getValue($report, ['document-uri', 'documentUri', 'documentURL']) ?? '',
-            'blocked_uri'         => $this->getValue($report, ['blocked-uri', 'blockedUri', 'blockedURL']),
-            'violated_directive'  => $this->getValue($report, ['violated-directive', 'violatedDirective']) ?? '',
+            'document_uri' => $this->getValue($report, ['document-uri', 'documentUri', 'documentURL']) ?? '',
+            'blocked_uri' => $this->getValue($report, ['blocked-uri', 'blockedUri', 'blockedURL']),
+            'violated_directive' => $this->getValue($report, ['violated-directive', 'violatedDirective']) ?? '',
             'effective_directive' => $this->getValue($report, ['effective-directive', 'effectiveDirective']),
-            'original_policy'     => $this->getValue($report, ['original-policy', 'originalPolicy']),
-            'disposition'         => $this->getValue($report, ['disposition']) ?? 'enforce',
-            'referrer'            => $this->getValue($report, ['referrer']),
-            'script_sample'       => $this->getValue($report, ['script-sample', 'scriptSample', 'sample']),
-            'source_file'         => $this->getValue($report, ['source-file', 'sourceFile']),
-            'line_number'         => $this->getIntValue($report, ['line-number', 'lineNumber']),
-            'column_number'       => $this->getIntValue($report, ['column-number', 'columnNumber']),
-            'status_code'         => $this->getValue($report, ['status-code', 'statusCode']),
-            'user_agent'          => request()->userAgent(),
-            'ip_address'          => config('artisanpack.security.csp.reporting.storeIpAddress', false)
+            'original_policy' => $this->getValue($report, ['original-policy', 'originalPolicy']),
+            'disposition' => $this->getValue($report, ['disposition']) ?? 'enforce',
+            'referrer' => $this->getValue($report, ['referrer']),
+            'script_sample' => $this->getValue($report, ['script-sample', 'scriptSample', 'sample']),
+            'source_file' => $this->getValue($report, ['source-file', 'sourceFile']),
+            'line_number' => $this->getIntValue($report, ['line-number', 'lineNumber']),
+            'column_number' => $this->getIntValue($report, ['column-number', 'columnNumber']),
+            'status_code' => $this->getValue($report, ['status-code', 'statusCode']),
+            'user_agent' => request()->userAgent(),
+            'ip_address' => config('artisanpack.security.csp.reporting.storeIpAddress', false)
                 ? request()->ip()
                 : null,
         ];
@@ -146,7 +145,7 @@ class CspViolationHandler
     protected function getValue(array $report, array $keys): ?string
     {
         foreach ($keys as $key) {
-            if (isset($report[$key]) && '' !== $report[$key]) {
+            if (isset($report[$key]) && $report[$key] !== '') {
                 return (string) $report[$key];
             }
         }
@@ -164,7 +163,7 @@ class CspViolationHandler
     {
         $value = $this->getValue($report, $keys);
 
-        return null !== $value ? (int) $value : null;
+        return $value !== null ? (int) $value : null;
     }
 
     /**
@@ -175,11 +174,11 @@ class CspViolationHandler
     protected function logViolation(array $data): void
     {
         Log::info('CSP Violation', [
-            'directive'    => $data['violated_directive'],
-            'blocked_uri'  => $data['blocked_uri'],
+            'directive' => $data['violated_directive'],
+            'blocked_uri' => $data['blocked_uri'],
             'document_uri' => $data['document_uri'],
-            'source_file'  => $data['source_file'],
-            'line_number'  => $data['line_number'],
+            'source_file' => $data['source_file'],
+            'line_number' => $data['line_number'],
         ]);
     }
 
@@ -196,10 +195,10 @@ class CspViolationHandler
             'csp_violation',
             "CSP violation: {$violation->violated_directive}",
             [
-                'blocked_uri'      => $violation->blocked_uri,
-                'document_uri'     => $violation->document_uri,
-                'source_file'      => $violation->source_file,
-                'line_number'      => $violation->line_number,
+                'blocked_uri' => $violation->blocked_uri,
+                'document_uri' => $violation->document_uri,
+                'source_file' => $violation->source_file,
+                'line_number' => $violation->line_number,
                 'occurrence_count' => $violation->occurrence_count,
             ],
         );

--- a/src/Services/EnvironmentValidationService.php
+++ b/src/Services/EnvironmentValidationService.php
@@ -32,15 +32,15 @@ class EnvironmentValidationService
      */
     public function validate(string $environment): array
     {
-        $this->errors   = [];
+        $this->errors = [];
         $this->warnings = [];
 
-        if ('production' === $environment) {
+        if ($environment === 'production') {
             $this->validateProductionEnvironment();
         }
 
         return [
-            'errors'   => $this->errors,
+            'errors' => $this->errors,
             'warnings' => $this->warnings,
         ];
     }

--- a/src/Testing/ApiSecurityAssertions.php
+++ b/src/Testing/ApiSecurityAssertions.php
@@ -24,7 +24,6 @@ trait ApiSecurityAssertions
      * @param  mixed  $user  The user model instance
      * @param  array  $abilities  Token abilities
      * @param  int|null  $expiresInMinutes  Token expiration
-     *
      * @return string The plain text token
      */
     protected function createTestApiToken(
@@ -44,7 +43,6 @@ trait ApiSecurityAssertions
      *
      * @param  mixed  $user  The user model instance
      * @param  array  $abilities  Token abilities
-     *
      * @return string The plain text token
      */
     protected function createExpiredTestApiToken($user, array $abilities = ['*']): string
@@ -68,7 +66,6 @@ trait ApiSecurityAssertions
      *
      * @param  mixed  $user  The user model instance
      * @param  array  $abilities  Token abilities
-     *
      * @return string The plain text token
      */
     protected function createRevokedTestApiToken($user, array $abilities = ['*']): string
@@ -102,7 +99,7 @@ trait ApiSecurityAssertions
     {
         $response->assertStatus(403);
 
-        if (null !== $ability) {
+        if ($ability !== null) {
             $response->assertJson([
                 'error' => 'insufficient_ability',
             ]);
@@ -182,7 +179,6 @@ trait ApiSecurityAssertions
      *
      * @param  mixed  $user  The user model instance
      * @param  array  $abilities  Token abilities
-     *
      * @return $this
      */
     protected function actingAsApiUser($user, array $abilities = ['*']): self

--- a/src/Testing/CiCd/GitHubActionsIntegration.php
+++ b/src/Testing/CiCd/GitHubActionsIntegration.php
@@ -27,8 +27,8 @@ class GitHubActionsIntegration
         foreach ($findings as $finding) {
             $level = match ($finding->severity) {
                 'critical', 'high' => 'error',
-                'medium'           => 'warning',
-                default            => 'notice',
+                'medium' => 'warning',
+                default => 'notice',
             };
 
             $file = '';
@@ -109,11 +109,11 @@ class GitHubActionsIntegration
         foreach ($summary['bySeverity'] ?? [] as $severity => $count) {
             $icon = match ($severity) {
                 'critical' => ':red_circle:',
-                'high'     => ':orange_circle:',
-                'medium'   => ':yellow_circle:',
-                'low'      => ':large_blue_circle:',
-                'info'     => ':white_circle:',
-                default    => '',
+                'high' => ':orange_circle:',
+                'medium' => ':yellow_circle:',
+                'low' => ':large_blue_circle:',
+                'info' => ':white_circle:',
+                default => '',
             };
             $md .= "| {$icon} ".ucfirst($severity)." | {$count} |\n";
         }
@@ -136,9 +136,9 @@ class GitHubActionsIntegration
             foreach ($topFindings as $finding) {
                 $icon = match ($finding->severity) {
                     'critical' => ':red_circle:',
-                    'high'     => ':orange_circle:',
-                    'medium'   => ':yellow_circle:',
-                    default    => ':white_circle:',
+                    'high' => ':orange_circle:',
+                    'medium' => ':yellow_circle:',
+                    default => ':white_circle:',
                 };
                 $md .= "- {$icon} **{$finding->title}** ({$finding->severity})\n";
             }
@@ -258,7 +258,7 @@ YAML;
      */
     public static function isGitHubActions(): bool
     {
-        return 'true' === getenv('GITHUB_ACTIONS');
+        return getenv('GITHUB_ACTIONS') === 'true';
     }
 
     /**

--- a/src/Testing/CiCd/SecurityGate.php
+++ b/src/Testing/CiCd/SecurityGate.php
@@ -56,8 +56,8 @@ class SecurityGate
 
         // Check severity thresholds
         $critical = $this->countBySeverity($findings, SecurityFinding::SEVERITY_CRITICAL);
-        $high     = $this->countBySeverity($findings, SecurityFinding::SEVERITY_HIGH);
-        $medium   = $this->countBySeverity($findings, SecurityFinding::SEVERITY_MEDIUM);
+        $high = $this->countBySeverity($findings, SecurityFinding::SEVERITY_HIGH);
+        $medium = $this->countBySeverity($findings, SecurityFinding::SEVERITY_MEDIUM);
 
         if ($critical > $this->maxCritical) {
             $failures[] = "Critical findings ({$critical}) exceed threshold ({$this->maxCritical})";
@@ -97,7 +97,7 @@ class SecurityGate
         foreach ($this->rules as $name => $check) {
             $result = $check($findings, $benchmarks);
 
-            if (true !== $result) {
+            if ($result !== true) {
                 $failures[] = "Rule '{$name}' failed: {$result}";
             }
         }
@@ -107,8 +107,8 @@ class SecurityGate
             failures: $failures,
             summary: [
                 'critical' => $critical,
-                'high'     => $high,
-                'medium'   => $medium,
+                'high' => $high,
+                'medium' => $medium,
             ],
         );
     }
@@ -186,9 +186,9 @@ class GateResult
     public function toArray(): array
     {
         return [
-            'passed'   => $this->passed,
+            'passed' => $this->passed,
             'failures' => $this->failures,
-            'summary'  => $this->summary,
+            'summary' => $this->summary,
         ];
     }
 }

--- a/src/Testing/CspAssertions.php
+++ b/src/Testing/CspAssertions.php
@@ -131,7 +131,7 @@ trait CspAssertions
 
         if (isset($directives['script-src'])) {
             // Allow unsafe-inline only when combined with nonce or strict-dynamic
-            $hasNonce         = preg_match("/'nonce-[A-Za-z0-9+\/=]+'/", $directives['script-src']);
+            $hasNonce = preg_match("/'nonce-[A-Za-z0-9+\/=]+'/", $directives['script-src']);
             $hasStrictDynamic = str_contains($directives['script-src'], "'strict-dynamic'");
 
             if (str_contains($directives['script-src'], "'unsafe-inline'")) {
@@ -174,7 +174,7 @@ trait CspAssertions
             'CSP header does not have report-uri',
         );
 
-        if (null !== $uri) {
+        if ($uri !== null) {
             $this->assertStringContainsString(
                 $uri,
                 $csp,
@@ -191,7 +191,7 @@ trait CspAssertions
         $csp = $response->headers->get('Content-Security-Policy')
             ?? $response->headers->get('Content-Security-Policy-Report-Only');
 
-        if (null === $csp) {
+        if ($csp === null) {
             return null;
         }
 
@@ -239,14 +239,14 @@ trait CspAssertions
     {
         return array_merge([
             'csp-report' => [
-                'document-uri'        => 'https://example.com/page',
-                'blocked-uri'         => 'https://evil.com/script.js',
-                'violated-directive'  => 'script-src',
+                'document-uri' => 'https://example.com/page',
+                'blocked-uri' => 'https://evil.com/script.js',
+                'violated-directive' => 'script-src',
                 'effective-directive' => 'script-src',
-                'original-policy'     => "default-src 'self'; script-src 'self'",
-                'disposition'         => 'enforce',
-                'referrer'            => '',
-                'status-code'         => 200,
+                'original-policy' => "default-src 'self'; script-src 'self'",
+                'disposition' => 'enforce',
+                'referrer' => '',
+                'status-code' => 200,
             ],
         ], $overrides);
     }
@@ -273,7 +273,7 @@ trait CspAssertions
     protected function parseCspDirectives(string $policy): array
     {
         $directives = [];
-        $parts      = explode(';', $policy);
+        $parts = explode(';', $policy);
 
         foreach ($parts as $part) {
             $part = trim($part);
@@ -282,11 +282,11 @@ trait CspAssertions
             }
 
             $spacePos = strpos($part, ' ');
-            if (false !== $spacePos) {
-                $name  = substr($part, 0, $spacePos);
+            if ($spacePos !== false) {
+                $name = substr($part, 0, $spacePos);
                 $value = substr($part, $spacePos + 1);
             } else {
-                $name  = $part;
+                $name = $part;
                 $value = '';
             }
 

--- a/src/Testing/PenetrationTesting/AttackResult.php
+++ b/src/Testing/PenetrationTesting/AttackResult.php
@@ -74,7 +74,7 @@ class AttackResult
      */
     public function isCritical(): bool
     {
-        return $this->vulnerable && 'critical' === $this->severity;
+        return $this->vulnerable && $this->severity === 'critical';
     }
 
     /**
@@ -82,7 +82,7 @@ class AttackResult
      */
     public function isHigh(): bool
     {
-        return $this->vulnerable && 'high' === $this->severity;
+        return $this->vulnerable && $this->severity === 'high';
     }
 
     /**
@@ -109,12 +109,12 @@ class AttackResult
     public function toArray(): array
     {
         return [
-            'attack'       => $this->attack,
-            'vulnerable'   => $this->vulnerable,
-            'severity'     => $this->severity,
-            'findings'     => $this->findings,
+            'attack' => $this->attack,
+            'vulnerable' => $this->vulnerable,
+            'severity' => $this->severity,
+            'findings' => $this->findings,
             'findingCount' => $this->getFindingCount(),
-            'metadata'     => $this->metadata,
+            'metadata' => $this->metadata,
         ];
     }
 }

--- a/src/Testing/PenetrationTesting/AttackResults.php
+++ b/src/Testing/PenetrationTesting/AttackResults.php
@@ -129,14 +129,14 @@ class AttackResults
     public function getSummary(): array
     {
         $summary = [
-            'total_attacks'  => count($this->results),
-            'vulnerable'     => 0,
+            'total_attacks' => count($this->results),
+            'vulnerable' => 0,
             'not_vulnerable' => 0,
-            'by_severity'    => [
+            'by_severity' => [
                 'critical' => 0,
-                'high'     => 0,
-                'medium'   => 0,
-                'low'      => 0,
+                'high' => 0,
+                'medium' => 0,
+                'low' => 0,
             ],
         ];
 

--- a/src/Testing/PenetrationTesting/AttackSimulator.php
+++ b/src/Testing/PenetrationTesting/AttackSimulator.php
@@ -65,7 +65,7 @@ class AttackSimulator
         $this->results = [];
 
         foreach ($this->attacks as $attack) {
-            $result          = $attack->execute($this->testCase, $uri, $options);
+            $result = $attack->execute($this->testCase, $uri, $options);
             $this->results[] = $result;
         }
 

--- a/src/Testing/PenetrationTesting/Attacks/AuthBypassAttack.php
+++ b/src/Testing/PenetrationTesting/Attacks/AuthBypassAttack.php
@@ -22,8 +22,8 @@ class AuthBypassAttack implements AttackInterface
     public function execute(object $testCase, string $uri, array $options = []): AttackResult
     {
         $vulnerabilities = [];
-        $method          = $options['method'] ?? 'get';
-        $requiresAuth    = $options['requires_auth'] ?? true;
+        $method = $options['method'] ?? 'get';
+        $requiresAuth = $options['requires_auth'] ?? true;
 
         // Test 1: Access without authentication
         try {
@@ -31,7 +31,7 @@ class AuthBypassAttack implements AttackInterface
 
             if ($requiresAuth && in_array($response->status(), [200, 201, 204])) {
                 $vulnerabilities[] = [
-                    'type'        => 'auth-missing',
+                    'type' => 'auth-missing',
                     'description' => 'Endpoint accessible without authentication',
                     'status_code' => $response->status(),
                 ];
@@ -101,9 +101,9 @@ class AuthBypassAttack implements AttackInterface
 
                 if (in_array($response->status(), [200, 201, 204])) {
                     $vulnerabilities[] = [
-                        'type'        => 'jwt-bypass',
+                        'type' => 'jwt-bypass',
                         'description' => 'Endpoint accepts manipulated JWT',
-                        'payload'     => substr($jwt, 0, 50).'...',
+                        'payload' => substr($jwt, 0, 50).'...',
                     ];
                     break;
                 }
@@ -138,7 +138,7 @@ class AuthBypassAttack implements AttackInterface
 
         // Check session configuration for security best practices
         $sessionConfig = config('session');
-        $issues        = [];
+        $issues = [];
 
         if (($sessionConfig['same_site'] ?? null) === 'none') {
             $issues[] = 'SameSite cookie attribute set to "none"';
@@ -154,12 +154,12 @@ class AuthBypassAttack implements AttackInterface
 
         // Always flag for manual verification since automated testing is not possible
         $vulnerabilities[] = [
-            'type'               => 'session-fixation-risk',
-            'description'        => 'Session fixation cannot be automatically verified. Manual review required to ensure session ID regeneration after authentication.',
-            'uri'                => $uri,
+            'type' => 'session-fixation-risk',
+            'description' => 'Session fixation cannot be automatically verified. Manual review required to ensure session ID regeneration after authentication.',
+            'uri' => $uri,
             'current_session_id' => substr($currentSessionId, 0, 8).'...',
-            'config_issues'      => $issues,
-            'recommendation'     => 'Verify that session()->regenerate() is called after successful authentication in your LoginController',
+            'config_issues' => $issues,
+            'recommendation' => 'Verify that session()->regenerate() is called after successful authentication in your LoginController',
         ];
     }
 
@@ -181,7 +181,7 @@ class AuthBypassAttack implements AttackInterface
         // Capture baseline response BEFORE testing with manipulated headers
         $baselineStatus = null;
         try {
-            $baseResponse   = $testCase->$method($uri);
+            $baseResponse = $testCase->$method($uri);
             $baselineStatus = $baseResponse->status();
         } catch (Exception $e) {
             // Baseline request failed, assume protected
@@ -199,10 +199,10 @@ class AuthBypassAttack implements AttackInterface
                 if (in_array($baselineStatus, [401, 403]) &&
                     in_array($response->status(), [200, 201, 204])) {
                     $vulnerabilities[] = [
-                        'type'        => 'header-bypass',
+                        'type' => 'header-bypass',
                         'description' => "Authentication bypassed via {$header} header",
-                        'header'      => $header,
-                        'value'       => $value,
+                        'header' => $header,
+                        'value' => $value,
                     ];
                 }
             } catch (Exception $e) {

--- a/src/Testing/PenetrationTesting/Attacks/CsrfAttack.php
+++ b/src/Testing/PenetrationTesting/Attacks/CsrfAttack.php
@@ -22,7 +22,7 @@ class CsrfAttack implements AttackInterface
     public function execute(object $testCase, string $uri, array $options = []): AttackResult
     {
         $vulnerabilities = [];
-        $method          = strtolower($options['method'] ?? 'post');
+        $method = strtolower($options['method'] ?? 'post');
 
         // Only test state-changing methods
         if (! in_array($method, ['post', 'put', 'patch', 'delete'])) {
@@ -42,11 +42,11 @@ class CsrfAttack implements AttackInterface
 
             // If request succeeds with an invalid token (not 419 Token Mismatch), it's vulnerable
             if ($response->status() < 400) {
-                $csrfVulnerable    = true;
+                $csrfVulnerable = true;
                 $vulnerabilities[] = [
-                    'type'        => 'csrf-missing',
+                    'type' => 'csrf-missing',
                     'description' => 'Endpoint accepts requests with invalid CSRF token',
-                    'method'      => strtoupper($method),
+                    'method' => strtoupper($method),
                     'status_code' => $response->status(),
                 ];
             }
@@ -59,11 +59,11 @@ class CsrfAttack implements AttackInterface
             try {
                 $response = $testCase->$method($uri, $data);
 
-                if ($response->status() < 400 && 419 !== $response->status()) {
+                if ($response->status() < 400 && $response->status() !== 419) {
                     $vulnerabilities[] = [
-                        'type'        => 'csrf-bypass',
+                        'type' => 'csrf-bypass',
                         'description' => 'Endpoint accepts requests without CSRF token',
-                        'method'      => strtoupper($method),
+                        'method' => strtoupper($method),
                         'status_code' => $response->status(),
                     ];
                 }
@@ -74,10 +74,10 @@ class CsrfAttack implements AttackInterface
 
         // Test 3: Check for SameSite cookie protection
         $sameSite = config('session.same_site', 'lax');
-        if ('none' === $sameSite || null === $sameSite) {
+        if ($sameSite === 'none' || $sameSite === null) {
             $vulnerabilities[] = [
-                'type'          => 'weak-samesite',
-                'description'   => 'Session cookie SameSite attribute is not protective',
+                'type' => 'weak-samesite',
+                'description' => 'Session cookie SameSite attribute is not protective',
                 'current_value' => $sameSite ?? 'not set',
             ];
         }

--- a/src/Testing/PenetrationTesting/Attacks/InjectionAttack.php
+++ b/src/Testing/PenetrationTesting/Attacks/InjectionAttack.php
@@ -23,8 +23,8 @@ class InjectionAttack implements AttackInterface
     public function execute(object $testCase, string $uri, array $options = []): AttackResult
     {
         $vulnerabilities = [];
-        $method          = $options['method'] ?? 'get';
-        $params          = $options['parameters'] ?? [];
+        $method = $options['method'] ?? 'get';
+        $params = $options['parameters'] ?? [];
 
         // If no parameters provided, try common parameter names
         if (empty($params)) {
@@ -89,19 +89,19 @@ class InjectionAttack implements AttackInterface
 
         foreach ($params as $paramName => $originalValue) {
             foreach ($payloads as $payload) {
-                $testParams             = $params;
+                $testParams = $params;
                 $testParams[$paramName] = $payload;
 
                 try {
                     $response = $testCase->$method($uri, $testParams);
-                    $content  = $response->getContent();
+                    $content = $response->getContent();
 
                     if ($this->hasCommandOutput($content)) {
                         $vulnerabilities[] = [
-                            'type'      => 'command-injection',
+                            'type' => 'command-injection',
                             'parameter' => $paramName,
-                            'payload'   => $payload,
-                            'evidence'  => $this->extractCommandEvidence($content),
+                            'payload' => $payload,
+                            'evidence' => $this->extractCommandEvidence($content),
                         ];
                     }
                 } catch (Exception $e) {
@@ -128,30 +128,30 @@ class InjectionAttack implements AttackInterface
 
         foreach ($params as $paramName => $originalValue) {
             foreach ($payloads as $payload) {
-                $testParams             = $params;
+                $testParams = $params;
                 $testParams[$paramName] = $payload;
 
                 try {
                     $response = $testCase->$method($uri, $testParams);
-                    $content  = $response->getContent();
+                    $content = $response->getContent();
 
                     // Check if template expression was evaluated
                     if ($this->templateWasEvaluated($payload, $content)) {
                         $vulnerabilities[] = [
-                            'type'      => 'template-injection',
+                            'type' => 'template-injection',
                             'parameter' => $paramName,
-                            'payload'   => $payload,
-                            'evidence'  => $this->extractTemplateEvidence($content, $payload),
+                            'payload' => $payload,
+                            'evidence' => $this->extractTemplateEvidence($content, $payload),
                         ];
                     }
                 } catch (Exception $e) {
                     // Template parsing errors might indicate injection possibility
                     if ($this->isTemplateException($e)) {
                         $vulnerabilities[] = [
-                            'type'      => 'template-error',
+                            'type' => 'template-error',
                             'parameter' => $paramName,
-                            'payload'   => $payload,
-                            'evidence'  => $e->getMessage(),
+                            'payload' => $payload,
+                            'evidence' => $e->getMessage(),
                         ];
                     }
                 }
@@ -176,7 +176,7 @@ class InjectionAttack implements AttackInterface
 
         foreach ($params as $paramName => $originalValue) {
             foreach ($payloads as $payload) {
-                $testParams             = $params;
+                $testParams = $params;
                 $testParams[$paramName] = $payload;
 
                 try {
@@ -185,9 +185,9 @@ class InjectionAttack implements AttackInterface
                     // Check if injected headers appear in response
                     if ($response->headers->has('Header') || $response->headers->has('Injected')) {
                         $vulnerabilities[] = [
-                            'type'      => 'header-injection',
+                            'type' => 'header-injection',
                             'parameter' => $paramName,
-                            'payload'   => $payload,
+                            'payload' => $payload,
                         ];
                     }
                 } catch (Exception $e) {
@@ -294,7 +294,7 @@ class InjectionAttack implements AttackInterface
     protected function determineSeverity(array $vulnerabilities): string
     {
         foreach ($vulnerabilities as $vuln) {
-            if ('command-injection' === $vuln['type']) {
+            if ($vuln['type'] === 'command-injection') {
                 return 'critical';
             }
         }

--- a/src/Testing/PenetrationTesting/Attacks/PathTraversalAttack.php
+++ b/src/Testing/PenetrationTesting/Attacks/PathTraversalAttack.php
@@ -35,8 +35,8 @@ class PathTraversalAttack implements AttackInterface
     public function execute(object $testCase, string $uri, array $options = []): AttackResult
     {
         $vulnerabilities = [];
-        $method          = $options['method'] ?? 'get';
-        $params          = $options['parameters'] ?? [];
+        $method = $options['method'] ?? 'get';
+        $params = $options['parameters'] ?? [];
 
         // If no parameters provided, try common file parameter names
         if (empty($params)) {
@@ -45,40 +45,40 @@ class PathTraversalAttack implements AttackInterface
 
         foreach ($params as $paramName => $originalValue) {
             foreach ($this->payloads as $payload) {
-                $testParams             = $params;
+                $testParams = $params;
                 $testParams[$paramName] = $payload;
 
                 try {
                     $response = $testCase->$method($uri, $testParams);
-                    $content  = $response->getContent();
+                    $content = $response->getContent();
 
                     // Check for sensitive file content
                     if ($this->hasSensitiveContent($content)) {
                         $vulnerabilities[] = [
-                            'type'      => 'path-traversal',
+                            'type' => 'path-traversal',
                             'parameter' => $paramName,
-                            'payload'   => $payload,
-                            'evidence'  => $this->extractEvidence($content),
+                            'payload' => $payload,
+                            'evidence' => $this->extractEvidence($content),
                         ];
                     }
 
                     // Check for error messages indicating path manipulation
                     if ($this->hasPathError($content)) {
                         $vulnerabilities[] = [
-                            'type'      => 'path-disclosure',
+                            'type' => 'path-disclosure',
                             'parameter' => $paramName,
-                            'payload'   => $payload,
-                            'evidence'  => $this->extractPathError($content),
+                            'payload' => $payload,
+                            'evidence' => $this->extractPathError($content),
                         ];
                     }
                 } catch (Exception $e) {
                     // Some payloads might cause exceptions
                     if ($this->isPathException($e)) {
                         $vulnerabilities[] = [
-                            'type'      => 'path-error',
+                            'type' => 'path-error',
                             'parameter' => $paramName,
-                            'payload'   => $payload,
-                            'evidence'  => $e->getMessage(),
+                            'payload' => $payload,
+                            'evidence' => $e->getMessage(),
                         ];
                     }
                 }
@@ -233,7 +233,7 @@ class PathTraversalAttack implements AttackInterface
         $pathKeywords = ['file', 'path', 'directory', 'open_basedir', 'fopen', 'include', 'require'];
 
         foreach ($pathKeywords as $keyword) {
-            if (false !== stripos($message, $keyword)) {
+            if (stripos($message, $keyword) !== false) {
                 return true;
             }
         }

--- a/src/Testing/PenetrationTesting/Attacks/SqlInjectionAttack.php
+++ b/src/Testing/PenetrationTesting/Attacks/SqlInjectionAttack.php
@@ -37,15 +37,15 @@ class SqlInjectionAttack implements AttackInterface
 
     public function __construct()
     {
-        $this->payloads          = SqlPayloads::getErrorBased();
+        $this->payloads = SqlPayloads::getErrorBased();
         $this->timeBasedPayloads = SqlPayloads::getTimeBased();
     }
 
     public function execute(object $testCase, string $uri, array $options = []): AttackResult
     {
         $vulnerabilities = [];
-        $method          = $options['method'] ?? 'get';
-        $params          = $options['parameters'] ?? [];
+        $method = $options['method'] ?? 'get';
+        $params = $options['parameters'] ?? [];
 
         // If no parameters provided, try common parameter names
         if (empty($params)) {
@@ -54,7 +54,7 @@ class SqlInjectionAttack implements AttackInterface
 
         foreach ($params as $paramName => $originalValue) {
             foreach ($this->payloads as $payload) {
-                $testParams             = $params;
+                $testParams = $params;
                 $testParams[$paramName] = $payload;
 
                 $startTime = microtime(true);
@@ -62,35 +62,35 @@ class SqlInjectionAttack implements AttackInterface
                 try {
                     $response = $testCase->$method($uri, $testParams);
                     $duration = microtime(true) - $startTime;
-                    $content  = $response->getContent();
+                    $content = $response->getContent();
 
                     // Check for error-based SQLi
                     if ($this->hasDbError($content)) {
                         $vulnerabilities[] = [
-                            'type'      => 'error-based',
+                            'type' => 'error-based',
                             'parameter' => $paramName,
-                            'payload'   => $payload,
-                            'evidence'  => $this->extractError($content),
+                            'payload' => $payload,
+                            'evidence' => $this->extractError($content),
                         ];
                     }
 
                     // Check for time-based SQLi (if payload is time-based)
                     if ($this->isTimeBased($payload) && $duration > 4.5) {
                         $vulnerabilities[] = [
-                            'type'      => 'time-based',
+                            'type' => 'time-based',
                             'parameter' => $paramName,
-                            'payload'   => $payload,
-                            'duration'  => $duration,
+                            'payload' => $payload,
+                            'duration' => $duration,
                         ];
                     }
                 } catch (Exception $e) {
                     // Database errors might throw exceptions
                     if ($this->isDbException($e)) {
                         $vulnerabilities[] = [
-                            'type'      => 'error-based',
+                            'type' => 'error-based',
                             'parameter' => $paramName,
-                            'payload'   => $payload,
-                            'evidence'  => $e->getMessage(),
+                            'payload' => $payload,
+                            'evidence' => $e->getMessage(),
                         ];
                     }
                 }
@@ -189,7 +189,7 @@ class SqlInjectionAttack implements AttackInterface
         $timeKeywords = ['SLEEP', 'WAITFOR', 'DELAY', 'pg_sleep', 'BENCHMARK'];
 
         foreach ($timeKeywords as $keyword) {
-            if (false !== stripos($payload, $keyword)) {
+            if (stripos($payload, $keyword) !== false) {
                 return true;
             }
         }

--- a/src/Testing/PenetrationTesting/Attacks/XssAttack.php
+++ b/src/Testing/PenetrationTesting/Attacks/XssAttack.php
@@ -38,8 +38,8 @@ class XssAttack implements AttackInterface
     public function execute(object $testCase, string $uri, array $options = []): AttackResult
     {
         $vulnerabilities = [];
-        $method          = $options['method'] ?? 'get';
-        $params          = $options['parameters'] ?? [];
+        $method = $options['method'] ?? 'get';
+        $params = $options['parameters'] ?? [];
 
         // If no parameters provided, try common parameter names
         if (empty($params)) {
@@ -48,20 +48,20 @@ class XssAttack implements AttackInterface
 
         foreach ($params as $paramName => $originalValue) {
             foreach ($this->payloads as $payload) {
-                $testParams             = $params;
+                $testParams = $params;
                 $testParams[$paramName] = $payload;
 
                 try {
                     $response = $testCase->$method($uri, $testParams);
-                    $content  = $response->getContent();
+                    $content = $response->getContent();
 
                     // Check if payload is reflected unescaped
                     if ($this->isPayloadReflected($content, $payload)) {
                         $vulnerabilities[] = [
-                            'type'      => $this->determineXssType($payload),
+                            'type' => $this->determineXssType($payload),
                             'parameter' => $paramName,
-                            'payload'   => $payload,
-                            'context'   => $this->detectContext($content, $payload),
+                            'payload' => $payload,
+                            'context' => $this->detectContext($content, $payload),
                         ];
                     }
                 } catch (Exception $e) {
@@ -164,13 +164,13 @@ class XssAttack implements AttackInterface
     {
         $pos = strpos($content, $payload);
 
-        if (false === $pos) {
+        if ($pos === false) {
             return 'unknown';
         }
 
         // Get surrounding context
         $before = substr($content, max(0, $pos - 50), 50);
-        $after  = substr($content, $pos + strlen($payload), 50);
+        $after = substr($content, $pos + strlen($payload), 50);
 
         // Check if inside script tag
         if (preg_match('/<script[^>]*>$/i', $before)) {

--- a/src/Testing/PenetrationTesting/Attacks/XssAttack.php
+++ b/src/Testing/PenetrationTesting/Attacks/XssAttack.php
@@ -170,7 +170,6 @@ class XssAttack implements AttackInterface
 
         // Get surrounding context
         $before = substr($content, max(0, $pos - 50), 50);
-        $after = substr($content, $pos + strlen($payload), 50);
 
         // Check if inside script tag
         if (preg_match('/<script[^>]*>$/i', $before)) {

--- a/src/Testing/Performance/BenchmarkResult.php
+++ b/src/Testing/Performance/BenchmarkResult.php
@@ -37,7 +37,7 @@ class BenchmarkResult
     {
         $withoutMean = $this->withoutSecurity['mean'] ?? 0;
 
-        if (0 == $withoutMean) {
+        if ($withoutMean == 0) {
             return 0;
         }
 
@@ -67,7 +67,7 @@ class BenchmarkResult
      */
     public function getSummary(): string
     {
-        $overhead   = $this->getOverhead();
+        $overhead = $this->getOverhead();
         $absoluteMs = $this->getAbsoluteOverhead();
 
         return sprintf(
@@ -86,12 +86,12 @@ class BenchmarkResult
     public function getComparison(): array
     {
         return [
-            'with_security'    => $this->withSecurity,
+            'with_security' => $this->withSecurity,
             'without_security' => $this->withoutSecurity,
-            'difference'       => [
+            'difference' => [
                 'mean' => ($this->withSecurity['mean'] ?? 0) - ($this->withoutSecurity['mean'] ?? 0),
-                'p95'  => ($this->withSecurity['p95'] ?? 0) - ($this->withoutSecurity['p95'] ?? 0),
-                'p99'  => ($this->withSecurity['p99'] ?? 0) - ($this->withoutSecurity['p99'] ?? 0),
+                'p95' => ($this->withSecurity['p95'] ?? 0) - ($this->withoutSecurity['p95'] ?? 0),
+                'p99' => ($this->withSecurity['p99'] ?? 0) - ($this->withoutSecurity['p99'] ?? 0),
             ],
         ];
     }
@@ -104,12 +104,12 @@ class BenchmarkResult
     public function toArray(): array
     {
         return [
-            'name'            => $this->name,
-            'iterations'      => $this->iterations,
-            'withSecurity'    => $this->withSecurity,
+            'name' => $this->name,
+            'iterations' => $this->iterations,
+            'withSecurity' => $this->withSecurity,
             'withoutSecurity' => $this->withoutSecurity,
-            'overhead'        => [
-                'percent'     => $this->getOverhead(),
+            'overhead' => [
+                'percent' => $this->getOverhead(),
                 'absolute_ms' => $this->getAbsoluteOverhead(),
             ],
             'acceptable' => $this->isAcceptable(),

--- a/src/Testing/Performance/ImpactAnalyzer.php
+++ b/src/Testing/Performance/ImpactAnalyzer.php
@@ -26,8 +26,8 @@ class ImpactAnalyzer
         'middleware' => 5.0,      // Max 5% for middleware
         'validation' => 10.0,     // Max 10% for validation
         'encryption' => 50.0,     // Higher tolerance for crypto
-        'hashing'    => 100.0,       // Hashing is intentionally slow
-        'default'    => 15.0,        // Default threshold
+        'hashing' => 100.0,       // Hashing is intentionally slow
+        'default' => 15.0,        // Default threshold
     ];
 
     /**
@@ -45,7 +45,7 @@ class ImpactAnalyzer
      */
     public function __construct(array $results = [], array $customThresholds = [])
     {
-        $this->results    = $results;
+        $this->results = $results;
         $this->thresholds = array_merge($this->thresholds, $customThresholds);
     }
 
@@ -82,7 +82,7 @@ class ImpactAnalyzer
 
         foreach ($this->results as $result) {
             $threshold = $this->getThresholdFor($result->name);
-            $overhead  = $result->getOverhead();
+            $overhead = $result->getOverhead();
 
             if ($overhead > $threshold) {
                 $findings[] = SecurityFinding::medium(
@@ -110,14 +110,14 @@ class ImpactAnalyzer
      */
     public function getSummary(): array
     {
-        $totalOverhead     = 0;
-        $acceptableCount   = 0;
+        $totalOverhead = 0;
+        $acceptableCount = 0;
         $unacceptableCount = 0;
-        $details           = [];
+        $details = [];
 
         foreach ($this->results as $result) {
-            $threshold  = $this->getThresholdFor($result->name);
-            $overhead   = $result->getOverhead();
+            $threshold = $this->getThresholdFor($result->name);
+            $overhead = $result->getOverhead();
             $acceptable = $overhead <= $threshold;
 
             $totalOverhead += $overhead;
@@ -129,9 +129,9 @@ class ImpactAnalyzer
             }
 
             $details[] = [
-                'name'       => $result->name,
-                'overhead'   => $overhead,
-                'threshold'  => $threshold,
+                'name' => $result->name,
+                'overhead' => $overhead,
+                'threshold' => $threshold,
                 'acceptable' => $acceptable,
             ];
         }
@@ -141,10 +141,10 @@ class ImpactAnalyzer
         return [
             'total_benchmarks' => $count,
             'average_overhead' => $count > 0 ? $totalOverhead / $count : 0,
-            'acceptable'       => $acceptableCount,
-            'unacceptable'     => $unacceptableCount,
-            'pass_rate'        => $count > 0 ? ($acceptableCount / $count) * 100 : 100,
-            'details'          => $details,
+            'acceptable' => $acceptableCount,
+            'unacceptable' => $unacceptableCount,
+            'pass_rate' => $count > 0 ? ($acceptableCount / $count) * 100 : 100,
+            'details' => $details,
         ];
     }
 
@@ -175,7 +175,7 @@ class ImpactAnalyzer
 
         foreach ($this->results as $result) {
             $threshold = $this->getThresholdFor($result->name);
-            $overhead  = $result->getOverhead();
+            $overhead = $result->getOverhead();
 
             if ($overhead > $threshold) {
                 $recommendations[$result->name] = $this->generateRecommendation($result, $overhead, $threshold);
@@ -193,9 +193,9 @@ class ImpactAnalyzer
     public function toArray(): array
     {
         return [
-            'summary'         => $this->getSummary(),
+            'summary' => $this->getSummary(),
             'recommendations' => $this->getRecommendations(),
-            'findings'        => array_map(fn ($f) => $f->toArray(), $this->analyze()),
+            'findings' => array_map(fn ($f) => $f->toArray(), $this->analyze()),
         ];
     }
 
@@ -231,7 +231,7 @@ class ImpactAnalyzer
     protected function generateRecommendation(BenchmarkResult $result, float $overhead, float $threshold): string
     {
         $absoluteMs = $result->getAbsoluteOverhead();
-        $name       = strtolower($result->name);
+        $name = strtolower($result->name);
 
         if (str_contains($name, 'middleware')) {
             return sprintf(

--- a/src/Testing/Performance/SecurityBenchmark.php
+++ b/src/Testing/Performance/SecurityBenchmark.php
@@ -82,7 +82,7 @@ class SecurityBenchmark
         int $iterations = 1000,
     ): BenchmarkResult {
         $request ??= Request::create('/test', 'GET');
-        $middleware  = app($middlewareClass);
+        $middleware = app($middlewareClass);
         $passthrough = fn ($r) => response('OK');
 
         return $this->benchmark(
@@ -221,7 +221,6 @@ class SecurityBenchmark
      * Calculate statistics from timing data.
      *
      * @param  array<int>  $times  Times in nanoseconds
-     *
      * @return array<string, float>
      */
     protected function calculateStats(array $times): array
@@ -229,32 +228,32 @@ class SecurityBenchmark
         sort($times);
         $count = count($times);
 
-        if (0 === $count) {
+        if ($count === 0) {
             return [
-                'min'    => 0,
-                'max'    => 0,
-                'mean'   => 0,
+                'min' => 0,
+                'max' => 0,
+                'mean' => 0,
                 'median' => 0,
-                'p95'    => 0,
-                'p99'    => 0,
+                'p95' => 0,
+                'p99' => 0,
                 'stddev' => 0,
             ];
         }
 
-        $sum  = array_sum($times);
+        $sum = array_sum($times);
         $mean = $sum / $count;
 
         // Calculate standard deviation
         $squaredDiffs = array_map(fn ($t) => pow($t - $mean, 2), $times);
-        $stddev       = sqrt(array_sum($squaredDiffs) / $count);
+        $stddev = sqrt(array_sum($squaredDiffs) / $count);
 
         return [
-            'min'    => min($times) / 1e6,         // Convert to ms
-            'max'    => max($times) / 1e6,
-            'mean'   => $mean / 1e6,
+            'min' => min($times) / 1e6,         // Convert to ms
+            'max' => max($times) / 1e6,
+            'mean' => $mean / 1e6,
             'median' => $times[(int) ($count / 2)] / 1e6,
-            'p95'    => $times[(int) ($count * 0.95)] / 1e6,
-            'p99'    => $times[(int) ($count * 0.99)] / 1e6,
+            'p95' => $times[(int) ($count * 0.95)] / 1e6,
+            'p99' => $times[(int) ($count * 0.99)] / 1e6,
             'stddev' => $stddev / 1e6,
         ];
     }

--- a/src/Testing/Reporting/Formats/HtmlReportFormat.php
+++ b/src/Testing/Reporting/Formats/HtmlReportFormat.php
@@ -176,7 +176,7 @@ HTML;
     protected function renderSummaryCards(array $summary): string
     {
         $severities = $summary['bySeverity'] ?? [];
-        $cards      = '';
+        $cards = '';
 
         foreach ($severities as $severity => $count) {
             $cards .= <<<HTML
@@ -209,10 +209,10 @@ HTML;
         $html = '';
 
         foreach ($findings as $finding) {
-            $title       = htmlspecialchars($finding->title);
+            $title = htmlspecialchars($finding->title);
             $description = htmlspecialchars($finding->description);
-            $category    = htmlspecialchars($finding->category);
-            $location    = $finding->location ? htmlspecialchars($finding->location) : 'N/A';
+            $category = htmlspecialchars($finding->category);
+            $location = $finding->location ? htmlspecialchars($finding->location) : 'N/A';
             $remediation = $finding->remediation ? htmlspecialchars($finding->remediation) : null;
 
             $remediationHtml = $remediation

--- a/src/Testing/Reporting/Formats/JsonReportFormat.php
+++ b/src/Testing/Reporting/Formats/JsonReportFormat.php
@@ -22,11 +22,11 @@ class JsonReportFormat implements ReportFormatInterface
     {
         $json = json_encode([
             'metadata' => $metadata,
-            'summary'  => $summary,
+            'summary' => $summary,
             'findings' => array_map(fn (SecurityFinding $f) => $f->toArray(), $findings),
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
-        if (false === $json) {
+        if ($json === false) {
             throw new RuntimeException('Failed to encode security report as JSON: '.json_last_error_msg());
         }
 

--- a/src/Testing/Reporting/Formats/JunitReportFormat.php
+++ b/src/Testing/Reporting/Formats/JunitReportFormat.php
@@ -20,7 +20,7 @@ class JunitReportFormat implements ReportFormatInterface
 {
     public function format(array $findings, array $metadata, array $summary): string
     {
-        $dom               = new DOMDocument('1.0', 'UTF-8');
+        $dom = new DOMDocument('1.0', 'UTF-8');
         $dom->formatOutput = true;
 
         // Create root testsuites element
@@ -73,7 +73,7 @@ class JunitReportFormat implements ReportFormatInterface
                     $testcase->appendChild($failure);
                 }
                 // Medium are warnings (system-out)
-                elseif ('medium' === $finding->severity) {
+                elseif ($finding->severity === 'medium') {
                     $systemOut = $dom->createElement('system-out');
                     $systemOut->appendChild($dom->createCDATASection(
                         "Warning: {$finding->description}\nLocation: {$finding->location}",
@@ -127,7 +127,6 @@ class JunitReportFormat implements ReportFormatInterface
      * Group findings by category.
      *
      * @param  array<SecurityFinding>  $findings
-     *
      * @return array<string, array<SecurityFinding>>
      */
     protected function groupByCategory(array $findings): array
@@ -148,7 +147,7 @@ class JunitReportFormat implements ReportFormatInterface
     {
         // Remove special characters and convert to PascalCase
         $cleaned = preg_replace('/[^a-zA-Z0-9\s]/', '', $category);
-        $words   = explode(' ', $cleaned);
+        $words = explode(' ', $cleaned);
 
         return implode('', array_map('ucfirst', array_map('strtolower', $words)));
     }

--- a/src/Testing/Reporting/Formats/MarkdownReportFormat.php
+++ b/src/Testing/Reporting/Formats/MarkdownReportFormat.php
@@ -111,7 +111,6 @@ class MarkdownReportFormat implements ReportFormatInterface
      * Group findings by severity.
      *
      * @param  array<SecurityFinding>  $findings
-     *
      * @return array<string, array<SecurityFinding>>
      */
     protected function groupBySeverity(array $findings): array
@@ -133,7 +132,7 @@ class MarkdownReportFormat implements ReportFormatInterface
     protected function renderSeveritySection(string $severity, array $findings): string
     {
         $icon = $this->getSeverityIcon($severity);
-        $md   = "### {$icon} ".ucfirst($severity).' ('.count($findings).")\n\n";
+        $md = "### {$icon} ".ucfirst($severity).' ('.count($findings).")\n\n";
 
         foreach ($findings as $finding) {
             $md .= $this->renderFinding($finding);
@@ -196,11 +195,11 @@ class MarkdownReportFormat implements ReportFormatInterface
     {
         return match ($severity) {
             'critical' => '🔴',
-            'high'     => '🟠',
-            'medium'   => '🟡',
-            'low'      => '🔵',
-            'info'     => '⚪',
-            default    => '⚫',
+            'high' => '🟠',
+            'medium' => '🟡',
+            'low' => '🔵',
+            'info' => '⚪',
+            default => '⚫',
         };
     }
 }

--- a/src/Testing/Reporting/Formats/SarifReportFormat.php
+++ b/src/Testing/Reporting/Formats/SarifReportFormat.php
@@ -19,27 +19,27 @@ class SarifReportFormat implements ReportFormatInterface
 {
     public function format(array $findings, array $metadata, array $summary): string
     {
-        $rules   = $this->generateRules($findings);
+        $rules = $this->generateRules($findings);
         $results = $this->generateResults($findings);
 
         $sarif = [
             '$schema' => 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
             'version' => '2.1.0',
-            'runs'    => [
+            'runs' => [
                 [
                     'tool' => [
                         'driver' => [
-                            'name'           => 'ArtisanPack Security Scanner',
+                            'name' => 'ArtisanPack Security Scanner',
                             'informationUri' => 'https://github.com/artisanpack/security',
-                            'version'        => $metadata['generatorVersion'] ?? '2.0.0',
-                            'rules'          => $rules,
+                            'version' => $metadata['generatorVersion'] ?? '2.0.0',
+                            'rules' => $rules,
                         ],
                     ],
-                    'results'     => $results,
+                    'results' => $results,
                     'invocations' => [
                         [
                             'executionSuccessful' => true,
-                            'endTimeUtc'          => $metadata['generatedAt'] ?? date('c'),
+                            'endTimeUtc' => $metadata['generatedAt'] ?? date('c'),
                         ],
                     ],
                 ],
@@ -68,12 +68,11 @@ class SarifReportFormat implements ReportFormatInterface
      * Generate SARIF rules from findings.
      *
      * @param  array<SecurityFinding>  $findings
-     *
      * @return array<array<string, mixed>>
      */
     protected function generateRules(array $findings): array
     {
-        $rules          = [];
+        $rules = [];
         $seenCategories = [];
 
         foreach ($findings as $finding) {
@@ -86,8 +85,8 @@ class SarifReportFormat implements ReportFormatInterface
             $seenCategories[$ruleId] = true;
 
             $rules[] = [
-                'id'               => $ruleId,
-                'name'             => $this->sanitizeRuleName($finding->category),
+                'id' => $ruleId,
+                'name' => $this->sanitizeRuleName($finding->category),
                 'shortDescription' => [
                     'text' => $finding->category,
                 ],
@@ -99,7 +98,7 @@ class SarifReportFormat implements ReportFormatInterface
                 ],
                 'properties' => [
                     'security-severity' => $this->severityToScore($finding->severity),
-                    'tags'              => ['security', $this->getOwaspTag($finding->category)],
+                    'tags' => ['security', $this->getOwaspTag($finding->category)],
                 ],
             ];
         }
@@ -111,7 +110,6 @@ class SarifReportFormat implements ReportFormatInterface
      * Generate SARIF results from findings.
      *
      * @param  array<SecurityFinding>  $findings
-     *
      * @return array<array<string, mixed>>
      */
     protected function generateResults(array $findings): array
@@ -120,20 +118,20 @@ class SarifReportFormat implements ReportFormatInterface
 
         foreach ($findings as $finding) {
             $result = [
-                'ruleId'  => $this->generateRuleId($finding->category),
-                'level'   => $this->severityToLevel($finding->severity),
+                'ruleId' => $this->generateRuleId($finding->category),
+                'level' => $this->severityToLevel($finding->severity),
                 'message' => [
                     'text' => $finding->description,
                 ],
                 'properties' => [
-                    'id'       => $finding->id,
+                    'id' => $finding->id,
                     'severity' => $finding->severity,
                 ],
             ];
 
             // Add location if available
             if ($finding->location) {
-                $location            = $this->parseLocation($finding->location);
+                $location = $this->parseLocation($finding->location);
                 $result['locations'] = [
                     [
                         'physicalLocation' => $location,
@@ -217,8 +215,8 @@ class SarifReportFormat implements ReportFormatInterface
     {
         return match ($severity) {
             'critical', 'high' => 'error',
-            'medium'           => 'warning',
-            default            => 'note',
+            'medium' => 'warning',
+            default => 'note',
         };
     }
 
@@ -229,10 +227,10 @@ class SarifReportFormat implements ReportFormatInterface
     {
         return match ($severity) {
             'critical' => '9.0',
-            'high'     => '7.0',
-            'medium'   => '5.0',
-            'low'      => '3.0',
-            default    => '1.0',
+            'high' => '7.0',
+            'medium' => '5.0',
+            'low' => '3.0',
+            default => '1.0',
         };
     }
 
@@ -264,7 +262,7 @@ class SarifReportFormat implements ReportFormatInterface
         // Check if location includes line number (e.g., "file.php:123")
         if (preg_match('/^(.+):(\d+)(?::(\d+))?$/', $location, $matches)) {
             $result['artifactLocation']['uri'] = $matches[1];
-            $result['region']                  = [
+            $result['region'] = [
                 'startLine' => (int) $matches[2],
             ];
 

--- a/src/Testing/Reporting/SecurityFinding.php
+++ b/src/Testing/Reporting/SecurityFinding.php
@@ -167,7 +167,7 @@ class SecurityFinding
      */
     public function isCritical(): bool
     {
-        return self::SEVERITY_CRITICAL === $this->severity;
+        return $this->severity === self::SEVERITY_CRITICAL;
     }
 
     /**
@@ -175,7 +175,7 @@ class SecurityFinding
      */
     public function isHigh(): bool
     {
-        return self::SEVERITY_HIGH === $this->severity;
+        return $this->severity === self::SEVERITY_HIGH;
     }
 
     /**
@@ -193,11 +193,11 @@ class SecurityFinding
     {
         return match ($this->severity) {
             self::SEVERITY_CRITICAL => 0,
-            self::SEVERITY_HIGH     => 1,
-            self::SEVERITY_MEDIUM   => 2,
-            self::SEVERITY_LOW      => 3,
-            self::SEVERITY_INFO     => 4,
-            default                 => 5,
+            self::SEVERITY_HIGH => 1,
+            self::SEVERITY_MEDIUM => 2,
+            self::SEVERITY_LOW => 3,
+            self::SEVERITY_INFO => 4,
+            default => 5,
         };
     }
 
@@ -209,15 +209,15 @@ class SecurityFinding
     public function toArray(): array
     {
         return [
-            'id'          => $this->id,
-            'title'       => $this->title,
+            'id' => $this->id,
+            'title' => $this->title,
             'description' => $this->description,
-            'severity'    => $this->severity,
-            'category'    => $this->category,
-            'location'    => $this->location,
-            'evidence'    => $this->evidence,
+            'severity' => $this->severity,
+            'category' => $this->category,
+            'location' => $this->location,
+            'evidence' => $this->evidence,
             'remediation' => $this->remediation,
-            'metadata'    => $this->metadata,
+            'metadata' => $this->metadata,
         ];
     }
 

--- a/src/Testing/Reporting/SecurityReportGenerator.php
+++ b/src/Testing/Reporting/SecurityReportGenerator.php
@@ -41,10 +41,10 @@ class SecurityReportGenerator implements SecurityReportInterface
         protected ?string $version = null,
     ) {
         $this->metadata = [
-            'generatedAt'      => now()->toIso8601String(),
-            'projectName'      => $projectName,
-            'version'          => $version,
-            'generator'        => 'ArtisanPack Security Testing Framework',
+            'generatedAt' => now()->toIso8601String(),
+            'projectName' => $projectName,
+            'version' => $version,
+            'generator' => 'ArtisanPack Security Testing Framework',
             'generatorVersion' => '2.0.0',
         ];
     }
@@ -87,12 +87,12 @@ class SecurityReportGenerator implements SecurityReportInterface
     public function generate(string $format = 'json'): string
     {
         return match ($format) {
-            'json'           => $this->generateJson(),
-            'html'           => $this->generateHtml(),
-            'junit'          => $this->generateJunit(),
-            'sarif'          => $this->generateSarif(),
+            'json' => $this->generateJson(),
+            'html' => $this->generateHtml(),
+            'junit' => $this->generateJunit(),
+            'sarif' => $this->generateSarif(),
             'markdown', 'md' => $this->generateMarkdown(),
-            default          => throw new InvalidArgumentException("Unknown format: {$format}"),
+            default => throw new InvalidArgumentException("Unknown format: {$format}"),
         };
     }
 
@@ -104,15 +104,15 @@ class SecurityReportGenerator implements SecurityReportInterface
     public function getSummary(): array
     {
         return [
-            'total'      => count($this->findings),
+            'total' => count($this->findings),
             'bySeverity' => [
                 'critical' => $this->countBySeverity([SecurityFinding::SEVERITY_CRITICAL]),
-                'high'     => $this->countBySeverity([SecurityFinding::SEVERITY_HIGH]),
-                'medium'   => $this->countBySeverity([SecurityFinding::SEVERITY_MEDIUM]),
-                'low'      => $this->countBySeverity([SecurityFinding::SEVERITY_LOW]),
-                'info'     => $this->countBySeverity([SecurityFinding::SEVERITY_INFO]),
+                'high' => $this->countBySeverity([SecurityFinding::SEVERITY_HIGH]),
+                'medium' => $this->countBySeverity([SecurityFinding::SEVERITY_MEDIUM]),
+                'low' => $this->countBySeverity([SecurityFinding::SEVERITY_LOW]),
+                'info' => $this->countBySeverity([SecurityFinding::SEVERITY_INFO]),
             ],
-            'byCategory'  => $this->groupByCategory(),
+            'byCategory' => $this->groupByCategory(),
             'hasBlocking' => $this->hasBlockingFindings(),
         ];
     }
@@ -147,7 +147,7 @@ class SecurityReportGenerator implements SecurityReportInterface
     {
         $content = $this->generate($format);
 
-        return false !== file_put_contents($path, $content);
+        return file_put_contents($path, $content) !== false;
     }
 
     /**

--- a/src/Testing/Scanners/ConfigurationScanner.php
+++ b/src/Testing/Scanners/ConfigurationScanner.php
@@ -79,8 +79,8 @@ class ConfigurationScanner implements ScannerInterface
         }
 
         // Check for non-production environment name in production-like URLs
-        $appUrl          = config('app.url', '');
-        $appEnv          = config('app.env', 'production');
+        $appUrl = config('app.url', '');
+        $appEnv = config('app.env', 'production');
         $isProductionUrl = str_contains($appUrl, 'prod') ||
                            str_contains($appUrl, '.com') ||
                            str_contains($appUrl, '.io') ||
@@ -103,7 +103,7 @@ class ConfigurationScanner implements ScannerInterface
     protected function scanDatabaseConfig(): void
     {
         $connection = config('database.default');
-        $dbConfig   = config("database.connections.{$connection}", []);
+        $dbConfig = config("database.connections.{$connection}", []);
 
         // Check for default/empty passwords
         $password = $dbConfig['password'] ?? '';
@@ -131,12 +131,12 @@ class ConfigurationScanner implements ScannerInterface
 
         // Check for SSL in production
         if (app()->environment('production')) {
-            $driver     = $dbConfig['driver'] ?? '';
+            $driver = $dbConfig['driver'] ?? '';
             $sslEnabled = false;
 
-            if ('mysql' === $driver) {
+            if ($driver === 'mysql') {
                 $sslEnabled = isset($dbConfig['options'][PDO::MYSQL_ATTR_SSL_CA]);
-            } elseif ('pgsql' === $driver) {
+            } elseif ($driver === 'pgsql') {
                 $sslEnabled = ($dbConfig['sslmode'] ?? 'prefer') === 'require';
             }
 
@@ -181,7 +181,7 @@ class ConfigurationScanner implements ScannerInterface
 
         // SameSite attribute
         $sameSite = config('session.same_site', 'lax');
-        if ('none' === $sameSite || null === $sameSite) {
+        if ($sameSite === 'none' || $sameSite === null) {
             $this->findings[] = SecurityFinding::medium(
                 'Weak SameSite Cookie Attribute',
                 "Session cookie SameSite is set to '{$sameSite}'",
@@ -205,7 +205,7 @@ class ConfigurationScanner implements ScannerInterface
 
         // Session driver
         $driver = config('session.driver', 'file');
-        if ('cookie' === $driver) {
+        if ($driver === 'cookie') {
             $this->findings[] = SecurityFinding::medium(
                 'Cookie Session Driver',
                 'Using cookie driver exposes session data to clients',
@@ -224,7 +224,7 @@ class ConfigurationScanner implements ScannerInterface
         $cacheDriver = config('cache.default', 'file');
 
         // File cache in shared hosting
-        if ('file' === $cacheDriver) {
+        if ($cacheDriver === 'file') {
             $cachePath = config('cache.stores.file.path', storage_path('framework/cache'));
 
             if (! File::exists($cachePath)) {
@@ -233,7 +233,7 @@ class ConfigurationScanner implements ScannerInterface
 
             // Check permissions (should not be world-readable)
             $perms = fileperms($cachePath);
-            if (false !== $perms && ($perms & 0x0004)) {
+            if ($perms !== false && ($perms & 0x0004)) {
                 $this->findings[] = SecurityFinding::low(
                     'Cache Directory World-Readable',
                     'Cache directory may be accessible to other users',
@@ -250,11 +250,11 @@ class ConfigurationScanner implements ScannerInterface
      */
     protected function scanMailConfig(): void
     {
-        $mailer       = config('mail.default', 'smtp');
+        $mailer = config('mail.default', 'smtp');
         $mailerConfig = config("mail.mailers.{$mailer}", []);
 
         // Check for unencrypted SMTP
-        if ('smtp' === $mailer) {
+        if ($mailer === 'smtp') {
             $encryption = $mailerConfig['encryption'] ?? null;
 
             if (app()->environment('production') && ! in_array($encryption, ['tls', 'ssl'])) {
@@ -275,11 +275,11 @@ class ConfigurationScanner implements ScannerInterface
     protected function scanFilesystemConfig(): void
     {
         $defaultDisk = config('filesystems.default', 'local');
-        $disks       = config('filesystems.disks', []);
+        $disks = config('filesystems.disks', []);
 
         foreach ($disks as $name => $disk) {
             // Check for public visibility on sensitive disks
-            if (($disk['visibility'] ?? 'private') === 'public' && 'public' !== $name) {
+            if (($disk['visibility'] ?? 'private') === 'public' && $name !== 'public') {
                 $this->findings[] = SecurityFinding::medium(
                     'Public Disk Visibility',
                     "Disk '{$name}' has public visibility by default",
@@ -360,7 +360,7 @@ class ConfigurationScanner implements ScannerInterface
 
         // Check .env file permissions
         $perms = fileperms($envPath);
-        if (false !== $perms && ($perms & 0x0004)) {
+        if ($perms !== false && ($perms & 0x0004)) {
             $this->findings[] = SecurityFinding::high(
                 '.env File World-Readable',
                 '.env file may be readable by other system users',

--- a/src/Testing/Scanners/DependencyScanner.php
+++ b/src/Testing/Scanners/DependencyScanner.php
@@ -35,7 +35,7 @@ class DependencyScanner implements ScannerInterface
         protected string $packageLockPath = 'package-lock.json',
     ) {
         $this->composerLockPath = base_path($composerLockPath);
-        $this->packageLockPath  = base_path($packageLockPath);
+        $this->packageLockPath = base_path($packageLockPath);
     }
 
     public function scan(): array
@@ -87,7 +87,7 @@ class DependencyScanner implements ScannerInterface
 
         $lock = json_decode(File::get($this->composerLockPath), true);
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
             $this->findings[] = SecurityFinding::medium(
                 'Invalid composer.lock',
                 'composer.lock file is not valid JSON',
@@ -107,7 +107,7 @@ class DependencyScanner implements ScannerInterface
         $advisories = $this->loadAdvisories();
 
         foreach ($packages as $package) {
-            $name    = $package['name'] ?? '';
+            $name = $package['name'] ?? '';
             $version = $package['version'] ?? '';
 
             // Check against known vulnerabilities
@@ -119,10 +119,10 @@ class DependencyScanner implements ScannerInterface
 
             // Check for abandoned packages
             if (isset($package['abandoned'])) {
-                $replacement      = is_string($package['abandoned']) ? $package['abandoned'] : 'unknown';
+                $replacement = is_string($package['abandoned']) ? $package['abandoned'] : 'unknown';
                 $this->findings[] = SecurityFinding::medium(
                     'Abandoned Package',
-                    "Package '{$name}' is abandoned".('unknown' !== $replacement ? ", suggested replacement: {$replacement}" : ''),
+                    "Package '{$name}' is abandoned".($replacement !== 'unknown' ? ", suggested replacement: {$replacement}" : ''),
                     'A06:2021-Vulnerable and Outdated Components',
                     $this->composerLockPath,
                     "Replace '{$name}' with an actively maintained alternative",
@@ -145,7 +145,7 @@ class DependencyScanner implements ScannerInterface
 
         $lock = json_decode(File::get($this->packageLockPath), true);
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
             $this->findings[] = SecurityFinding::medium(
                 'Invalid package-lock.json',
                 'package-lock.json file is not valid JSON',
@@ -161,11 +161,11 @@ class DependencyScanner implements ScannerInterface
 
         // Check each package
         foreach ($packages as $path => $package) {
-            if ('' === $path) {
+            if ($path === '') {
                 continue; // Skip root package
             }
 
-            $name    = str_replace('node_modules/', '', $path);
+            $name = str_replace('node_modules/', '', $path);
             $version = $package['version'] ?? '';
 
             // Basic check for known vulnerable packages
@@ -186,7 +186,7 @@ class DependencyScanner implements ScannerInterface
     {
         if ($this->advisoryDatabase && File::exists($this->advisoryDatabase)) {
             $content = File::get($this->advisoryDatabase);
-            $data    = json_decode($content, true);
+            $data = json_decode($content, true);
 
             return $data ?? [];
         }
@@ -195,18 +195,18 @@ class DependencyScanner implements ScannerInterface
         return [
             'symfony/http-foundation' => [
                 [
-                    'cve'               => 'CVE-2022-24894',
-                    'title'             => 'Cookie Parsing Vulnerability',
+                    'cve' => 'CVE-2022-24894',
+                    'title' => 'Cookie Parsing Vulnerability',
                     'affected_versions' => '<5.4.20,>=6.0.0 <6.0.20,>=6.1.0 <6.1.12,>=6.2.0 <6.2.6',
-                    'severity'          => 'high',
+                    'severity' => 'high',
                 ],
             ],
             'guzzlehttp/guzzle' => [
                 [
-                    'cve'               => 'CVE-2022-31090',
-                    'title'             => 'CURLOPT_HTTPAUTH leak',
+                    'cve' => 'CVE-2022-31090',
+                    'title' => 'CURLOPT_HTTPAUTH leak',
                     'affected_versions' => '<6.5.8,>=7.0.0 <7.4.5',
-                    'severity'          => 'high',
+                    'severity' => 'high',
                 ],
             ],
         ];
@@ -216,7 +216,6 @@ class DependencyScanner implements ScannerInterface
      * Check if a package version is vulnerable.
      *
      * @param  array<string, array<array<string, mixed>>>  $advisories
-     *
      * @return array<array<string, mixed>>
      */
     protected function checkPackageVulnerabilities(string $name, string $version, array $advisories): array
@@ -230,12 +229,12 @@ class DependencyScanner implements ScannerInterface
         foreach ($advisories[$name] as $advisory) {
             if ($this->versionMatchesConstraint($version, $advisory['affected_versions'] ?? '')) {
                 $vulnerabilities[] = [
-                    'id'          => $advisory['cve'] ?? 'UNKNOWN',
-                    'title'       => "Vulnerable Package: {$name}",
+                    'id' => $advisory['cve'] ?? 'UNKNOWN',
+                    'title' => "Vulnerable Package: {$name}",
                     'description' => $advisory['title'] ?? 'Known vulnerability in package',
-                    'severity'    => $advisory['severity'] ?? 'medium',
-                    'category'    => 'A06:2021-Vulnerable and Outdated Components',
-                    'location'    => "{$name}@{$version}",
+                    'severity' => $advisory['severity'] ?? 'medium',
+                    'category' => 'A06:2021-Vulnerable and Outdated Components',
+                    'location' => "{$name}@{$version}",
                     'remediation' => 'Update to a patched version',
                 ];
             }
@@ -255,18 +254,18 @@ class DependencyScanner implements ScannerInterface
         $knownVulnerabilities = [
             'lodash' => [
                 [
-                    'cve'      => 'CVE-2021-23337',
+                    'cve' => 'CVE-2021-23337',
                     'affected' => '<4.17.21',
                     'severity' => 'high',
-                    'title'    => 'Command Injection',
+                    'title' => 'Command Injection',
                 ],
             ],
             'axios' => [
                 [
-                    'cve'      => 'CVE-2021-3749',
+                    'cve' => 'CVE-2021-3749',
                     'affected' => '<0.21.2',
                     'severity' => 'high',
-                    'title'    => 'Server-Side Request Forgery',
+                    'title' => 'Server-Side Request Forgery',
                 ],
             ],
         ];
@@ -277,12 +276,12 @@ class DependencyScanner implements ScannerInterface
             foreach ($knownVulnerabilities[$name] as $vuln) {
                 if ($this->versionMatchesConstraint($version, $vuln['affected'])) {
                     $vulnerabilities[] = [
-                        'id'          => $vuln['cve'],
-                        'title'       => "Vulnerable NPM Package: {$name}",
+                        'id' => $vuln['cve'],
+                        'title' => "Vulnerable NPM Package: {$name}",
                         'description' => $vuln['title'],
-                        'severity'    => $vuln['severity'],
-                        'category'    => 'A06:2021-Vulnerable and Outdated Components',
-                        'location'    => "{$name}@{$version} (npm)",
+                        'severity' => $vuln['severity'],
+                        'category' => 'A06:2021-Vulnerable and Outdated Components',
+                        'location' => "{$name}@{$version} (npm)",
                         'remediation' => 'Update to a patched version',
                     ];
                 }
@@ -300,9 +299,9 @@ class DependencyScanner implements ScannerInterface
     protected function checkOutdatedPackages(array $packages): void
     {
         foreach ($packages as $package) {
-            $name    = $package['name'] ?? '';
+            $name = $package['name'] ?? '';
             $version = $package['version'] ?? '';
-            $time    = $package['time'] ?? null;
+            $time = $package['time'] ?? null;
 
             if ($time) {
                 $packageDate = strtotime($time);

--- a/src/Testing/Scanners/HeaderScanner.php
+++ b/src/Testing/Scanners/HeaderScanner.php
@@ -80,38 +80,38 @@ class HeaderScanner implements ScannerInterface
     {
         $requiredHeaders = [
             'X-Frame-Options' => [
-                'severity'    => 'medium',
-                'title'       => 'Missing X-Frame-Options',
+                'severity' => 'medium',
+                'title' => 'Missing X-Frame-Options',
                 'description' => 'X-Frame-Options header is not set, allowing clickjacking',
                 'remediation' => 'Add X-Frame-Options: DENY or SAMEORIGIN',
             ],
             'X-Content-Type-Options' => [
-                'severity'    => 'medium',
-                'title'       => 'Missing X-Content-Type-Options',
+                'severity' => 'medium',
+                'title' => 'Missing X-Content-Type-Options',
                 'description' => 'X-Content-Type-Options header is not set',
                 'remediation' => 'Add X-Content-Type-Options: nosniff',
             ],
             'Strict-Transport-Security' => [
-                'severity'    => 'high',
-                'title'       => 'Missing HSTS Header',
+                'severity' => 'high',
+                'title' => 'Missing HSTS Header',
                 'description' => 'Strict-Transport-Security header is not set',
                 'remediation' => 'Add Strict-Transport-Security: max-age=31536000; includeSubDomains',
             ],
             'Content-Security-Policy' => [
-                'severity'    => 'high',
-                'title'       => 'Missing Content-Security-Policy',
+                'severity' => 'high',
+                'title' => 'Missing Content-Security-Policy',
                 'description' => 'No Content-Security-Policy header to prevent XSS',
                 'remediation' => 'Implement a Content-Security-Policy',
             ],
             'Referrer-Policy' => [
-                'severity'    => 'low',
-                'title'       => 'Missing Referrer-Policy',
+                'severity' => 'low',
+                'title' => 'Missing Referrer-Policy',
                 'description' => 'Referrer-Policy header is not set',
                 'remediation' => 'Add Referrer-Policy: strict-origin-when-cross-origin',
             ],
             'Permissions-Policy' => [
-                'severity'    => 'low',
-                'title'       => 'Missing Permissions-Policy',
+                'severity' => 'low',
+                'title' => 'Missing Permissions-Policy',
                 'description' => 'Permissions-Policy header is not set',
                 'remediation' => 'Add Permissions-Policy to restrict browser features',
             ],
@@ -143,13 +143,13 @@ class HeaderScanner implements ScannerInterface
     protected function scanInformationDisclosure(): void
     {
         $disclosureHeaders = [
-            'Server'              => 'Server version information exposed',
-            'X-Powered-By'        => 'Technology stack information exposed',
-            'X-AspNet-Version'    => 'ASP.NET version information exposed',
+            'Server' => 'Server version information exposed',
+            'X-Powered-By' => 'Technology stack information exposed',
+            'X-AspNet-Version' => 'ASP.NET version information exposed',
             'X-AspNetMvc-Version' => 'ASP.NET MVC version exposed',
-            'X-Generator'         => 'Generator information exposed',
-            'X-Drupal-Cache'      => 'Drupal cache information exposed',
-            'X-Varnish'           => 'Varnish cache information exposed',
+            'X-Generator' => 'Generator information exposed',
+            'X-Drupal-Cache' => 'Drupal cache information exposed',
+            'X-Varnish' => 'Varnish cache information exposed',
         ];
 
         foreach ($disclosureHeaders as $header => $description) {
@@ -343,7 +343,7 @@ class HeaderScanner implements ScannerInterface
             ?? $this->responseHeaders[$name]
             ?? null;
 
-        if (null === $value) {
+        if ($value === null) {
             return [];
         }
 

--- a/src/Testing/Scanners/OwaspScanner.php
+++ b/src/Testing/Scanners/OwaspScanner.php
@@ -59,16 +59,16 @@ class OwaspScanner implements ScannerInterface
 
         foreach ($this->categories as $category) {
             match ($category) {
-                'A01'   => $this->scanBrokenAccessControl(),
-                'A02'   => $this->scanCryptographicFailures(),
-                'A03'   => $this->scanInjection(),
-                'A04'   => $this->scanInsecureDesign(),
-                'A05'   => $this->scanSecurityMisconfiguration(),
-                'A06'   => $this->scanVulnerableComponents(),
-                'A07'   => $this->scanAuthenticationFailures(),
-                'A08'   => $this->scanIntegrityFailures(),
-                'A09'   => $this->scanLoggingFailures(),
-                'A10'   => $this->scanSsrf(),
+                'A01' => $this->scanBrokenAccessControl(),
+                'A02' => $this->scanCryptographicFailures(),
+                'A03' => $this->scanInjection(),
+                'A04' => $this->scanInsecureDesign(),
+                'A05' => $this->scanSecurityMisconfiguration(),
+                'A06' => $this->scanVulnerableComponents(),
+                'A07' => $this->scanAuthenticationFailures(),
+                'A08' => $this->scanIntegrityFailures(),
+                'A09' => $this->scanLoggingFailures(),
+                'A10' => $this->scanSsrf(),
                 default => null,
             };
         }
@@ -96,7 +96,7 @@ class OwaspScanner implements ScannerInterface
 
         foreach ($routes as $route) {
             $middleware = $route->middleware();
-            $uri        = $route->uri();
+            $uri = $route->uri();
 
             // Skip API routes that might use token auth
             if (str_starts_with($uri, 'api/')) {
@@ -162,7 +162,7 @@ class OwaspScanner implements ScannerInterface
 
         // Check password hashing
         $hashDriver = config('hashing.driver', 'bcrypt');
-        if ('md5' === $hashDriver || 'sha1' === $hashDriver) {
+        if ($hashDriver === 'md5' || $hashDriver === 'sha1') {
             $this->findings[] = SecurityFinding::critical(
                 'Weak Password Hashing',
                 "Password hashing driver '{$hashDriver}' is cryptographically weak",
@@ -192,15 +192,15 @@ class OwaspScanner implements ScannerInterface
     {
         // Scan for raw SQL queries in codebase
         $this->scanFilesForPatterns([
-            '/DB::raw\s*\(\s*["\'].*\$/'     => 'Potential SQL injection via DB::raw with variable',
-            '/->whereRaw\s*\(\s*["\'].*\$/'  => 'Potential SQL injection via whereRaw with variable',
+            '/DB::raw\s*\(\s*["\'].*\$/' => 'Potential SQL injection via DB::raw with variable',
+            '/->whereRaw\s*\(\s*["\'].*\$/' => 'Potential SQL injection via whereRaw with variable',
             '/->selectRaw\s*\(\s*["\'].*\$/' => 'Potential SQL injection via selectRaw with variable',
-            '/eval\s*\(/'                    => 'Use of eval() function',
-            '/exec\s*\(.*\$/'                => 'Command execution with variable input',
-            '/shell_exec\s*\(.*\$/'          => 'Shell execution with variable input',
-            '/system\s*\(.*\$/'              => 'System command with variable input',
-            '/passthru\s*\(.*\$/'            => 'Passthru command with variable input',
-            '/`.*\$.*`/'                     => 'Backtick shell execution with variable',
+            '/eval\s*\(/' => 'Use of eval() function',
+            '/exec\s*\(.*\$/' => 'Command execution with variable input',
+            '/shell_exec\s*\(.*\$/' => 'Shell execution with variable input',
+            '/system\s*\(.*\$/' => 'System command with variable input',
+            '/passthru\s*\(.*\$/' => 'Passthru command with variable input',
+            '/`.*\$.*`/' => 'Backtick shell execution with variable',
         ], 'A03:2021-Injection');
     }
 
@@ -319,8 +319,8 @@ class OwaspScanner implements ScannerInterface
     {
         // Check for unverified redirects
         $this->scanFilesForPatterns([
-            '/redirect\s*\(\s*\$_GET/'                           => 'Unvalidated redirect from GET parameter',
-            '/redirect\s*\(\s*\$_POST/'                          => 'Unvalidated redirect from POST parameter',
+            '/redirect\s*\(\s*\$_GET/' => 'Unvalidated redirect from GET parameter',
+            '/redirect\s*\(\s*\$_POST/' => 'Unvalidated redirect from POST parameter',
             '/redirect\s*\(\s*request\s*\(\s*[\'"].*[\'"]\s*\)/' => 'Potential unvalidated redirect',
         ], 'A08:2021-Software and Data Integrity Failures');
 
@@ -354,7 +354,7 @@ class OwaspScanner implements ScannerInterface
 
         // Check log channel configuration
         $logChannel = config('logging.default');
-        if ('null' === $logChannel && app()->environment('production')) {
+        if ($logChannel === 'null' && app()->environment('production')) {
             $this->findings[] = SecurityFinding::high(
                 'Logging Disabled in Production',
                 'Log channel is set to null in production',
@@ -371,9 +371,9 @@ class OwaspScanner implements ScannerInterface
     protected function scanSsrf(): void
     {
         $this->scanFilesForPatterns([
-            '/file_get_contents\s*\(\s*\$/'       => 'Potential SSRF via file_get_contents with variable URL',
-            '/curl_setopt.*CURLOPT_URL.*\$/'      => 'Potential SSRF via cURL with variable URL',
-            '/Http::get\s*\(\s*\$/'               => 'Potential SSRF via HTTP client with variable URL',
+            '/file_get_contents\s*\(\s*\$/' => 'Potential SSRF via file_get_contents with variable URL',
+            '/curl_setopt.*CURLOPT_URL.*\$/' => 'Potential SSRF via cURL with variable URL',
+            '/Http::get\s*\(\s*\$/' => 'Potential SSRF via HTTP client with variable URL',
             '/fopen\s*\(\s*[\'"]https?:\/\/.*\$/' => 'Potential SSRF via fopen with variable URL',
         ], 'A10:2021-Server-Side Request Forgery');
     }
@@ -394,12 +394,12 @@ class OwaspScanner implements ScannerInterface
         $files = File::allFiles($appPath);
 
         foreach ($files as $file) {
-            if ('php' !== $file->getExtension()) {
+            if ($file->getExtension() !== 'php') {
                 continue;
             }
 
             $content = File::get($file->getPathname());
-            $lines   = explode("\n", $content);
+            $lines = explode("\n", $content);
 
             foreach ($patterns as $pattern => $description) {
                 foreach ($lines as $lineNumber => $line) {

--- a/src/Testing/SecurityTestCase.php
+++ b/src/Testing/SecurityTestCase.php
@@ -87,7 +87,7 @@ abstract class SecurityTestCase extends TestCase
      */
     public function getFindings(?string $severity = null): array
     {
-        if (null === $severity) {
+        if ($severity === null) {
             return $this->securityFindings;
         }
 
@@ -118,18 +118,18 @@ abstract class SecurityTestCase extends TestCase
         }
 
         $critical = $this->getFindings(SecurityFinding::SEVERITY_CRITICAL);
-        $high     = $this->getFindings(SecurityFinding::SEVERITY_HIGH);
-        $medium   = $this->getFindings(SecurityFinding::SEVERITY_MEDIUM);
-        $low      = $this->getFindings(SecurityFinding::SEVERITY_LOW);
-        $info     = $this->getFindings(SecurityFinding::SEVERITY_INFO);
+        $high = $this->getFindings(SecurityFinding::SEVERITY_HIGH);
+        $medium = $this->getFindings(SecurityFinding::SEVERITY_MEDIUM);
+        $low = $this->getFindings(SecurityFinding::SEVERITY_LOW);
+        $info = $this->getFindings(SecurityFinding::SEVERITY_INFO);
 
         // Define severity order for comparison
         $severityOrder = [
             SecurityFinding::SEVERITY_CRITICAL => 0,
-            SecurityFinding::SEVERITY_HIGH     => 1,
-            SecurityFinding::SEVERITY_MEDIUM   => 2,
-            SecurityFinding::SEVERITY_LOW      => 3,
-            SecurityFinding::SEVERITY_INFO     => 4,
+            SecurityFinding::SEVERITY_HIGH => 1,
+            SecurityFinding::SEVERITY_MEDIUM => 2,
+            SecurityFinding::SEVERITY_LOW => 3,
+            SecurityFinding::SEVERITY_INFO => 4,
         ];
 
         $thresholdLevel = $severityOrder[$this->severityThreshold] ?? 2; // Default to medium
@@ -232,7 +232,7 @@ abstract class SecurityTestCase extends TestCase
 
         for ($i = 0; $i < $attempts; $i++) {
             $response = $this->$method($uri);
-            if (429 === $response->status()) {
+            if ($response->status() === 429) {
                 $rateLimited = true;
                 break;
             }

--- a/src/Testing/Traits/SecurityRegressionTests.php
+++ b/src/Testing/Traits/SecurityRegressionTests.php
@@ -54,7 +54,7 @@ trait SecurityRegressionTests
     protected function registerSecurityRegression(string $id, callable $test, ?string $description = null): void
     {
         $this->securityRegressions[$id] = [
-            'test'        => $test,
+            'test' => $test,
             'description' => $description,
         ];
     }
@@ -69,21 +69,21 @@ trait SecurityRegressionTests
         $this->regressionResults = [];
 
         foreach ($this->securityRegressions as $id => $config) {
-            $test        = $config['test'];
+            $test = $config['test'];
             $description = $config['description'] ?? $id;
 
             try {
                 $test();
                 $this->regressionResults[$id] = [
-                    'status'      => 'passed',
+                    'status' => 'passed',
                     'description' => $description,
                 ];
             } catch (Throwable $e) {
                 $this->regressionResults[$id] = [
-                    'status'      => 'failed',
+                    'status' => 'failed',
                     'description' => $description,
-                    'error'       => $e->getMessage(),
-                    'trace'       => $e->getTraceAsString(),
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
                 ];
 
                 $this->recordFinding(SecurityFinding::critical(
@@ -240,7 +240,7 @@ trait SecurityRegressionTests
         $failed = 0;
 
         foreach ($this->regressionResults as $result) {
-            if ('passed' === $result['status']) {
+            if ($result['status'] === 'passed') {
                 $passed++;
             } else {
                 $failed++;
@@ -248,7 +248,7 @@ trait SecurityRegressionTests
         }
 
         return [
-            'total'  => count($this->regressionResults),
+            'total' => count($this->regressionResults),
             'passed' => $passed,
             'failed' => $failed,
         ];
@@ -260,7 +260,7 @@ trait SecurityRegressionTests
     protected function allRegressionsPassing(): bool
     {
         foreach ($this->regressionResults as $result) {
-            if ('passed' !== $result['status']) {
+            if ($result['status'] !== 'passed') {
                 return false;
             }
         }

--- a/src/Testing/Traits/TestsAuthentication.php
+++ b/src/Testing/Traits/TestsAuthentication.php
@@ -50,13 +50,13 @@ trait TestsAuthentication
     {
         // Test with invalid token
         $response = $this->post($uri, [
-            'token'                 => 'invalid-token',
-            'email'                 => 'test@example.com',
-            'password'              => 'NewPassword123!',
+            'token' => 'invalid-token',
+            'email' => 'test@example.com',
+            'password' => 'NewPassword123!',
             'password_confirmation' => 'NewPassword123!',
         ]);
 
-        if (200 === $response->status()) {
+        if ($response->status() === 200) {
             $this->recordFinding(SecurityFinding::critical(
                 'Password Reset Token Not Validated',
                 'Password reset endpoint accepts invalid tokens',
@@ -104,18 +104,18 @@ trait TestsAuthentication
     {
         // Test with invalid user
         $invalidUserResponse = $this->post($loginUri, [
-            $emailField    => 'nonexistent@example.com',
+            $emailField => 'nonexistent@example.com',
             $passwordField => 'SomePassword123!',
         ]);
 
         // Test with valid user but wrong password (requires a real user in test)
         $invalidPasswordResponse = $this->post($loginUri, [
-            $emailField    => 'test@example.com',
+            $emailField => 'test@example.com',
             $passwordField => 'WrongPassword123!',
         ]);
 
         // Both should return the same error structure
-        $invalidUserErrors     = $invalidUserResponse->json('errors') ?? $invalidUserResponse->json('message');
+        $invalidUserErrors = $invalidUserResponse->json('errors') ?? $invalidUserResponse->json('message');
         $invalidPasswordErrors = $invalidPasswordResponse->json('errors') ?? $invalidPasswordResponse->json('message');
 
         // Check if error messages are the same (preventing enumeration)
@@ -171,7 +171,7 @@ trait TestsAuthentication
         for ($i = 0; $i < $maxAttempts + 2; $i++) {
             $lastResponse = $this->post($loginUri, $credentials);
 
-            if (429 === $lastResponse->status()) {
+            if ($lastResponse->status() === 429) {
                 return $lastResponse;
             }
         }

--- a/src/Testing/Traits/TestsAuthorization.php
+++ b/src/Testing/Traits/TestsAuthorization.php
@@ -29,7 +29,7 @@ trait TestsAuthorization
     ): void {
         $response = $this->actingAs($user)->$method($uri, $data);
 
-        if (403 !== $response->status()) {
+        if ($response->status() !== 403) {
             $this->recordFinding(SecurityFinding::high(
                 'Missing Authorization Check',
                 "User without permission can access {$method} {$uri}",
@@ -158,7 +158,7 @@ trait TestsAuthorization
         } else {
             // For non-Eloquent implementations, we cannot verify the change
             // but we can check the response status
-            if (200 === $response->status() || 204 === $response->status()) {
+            if ($response->status() === 200 || $response->status() === 204) {
                 $this->recordFinding(SecurityFinding::medium(
                     'Potential Mass Assignment - Role Escalation',
                     "Role change request accepted (status {$response->status()}). Manual verification needed.",
@@ -195,7 +195,7 @@ trait TestsAuthorization
 
         $allowedOrigin = $response->headers->get('Access-Control-Allow-Origin');
 
-        if ('*' === $allowedOrigin || $allowedOrigin === $maliciousOrigin) {
+        if ($allowedOrigin === '*' || $allowedOrigin === $maliciousOrigin) {
             $this->recordFinding(SecurityFinding::medium(
                 'Permissive CORS Configuration',
                 "Endpoint allows requests from {$maliciousOrigin}",

--- a/src/Testing/Traits/TestsCryptography.php
+++ b/src/Testing/Traits/TestsCryptography.php
@@ -71,7 +71,7 @@ trait TestsCryptography
         }
 
         // Check bcrypt cost factor
-        if ('bcrypt' === $hashDriver) {
+        if ($hashDriver === 'bcrypt') {
             $rounds = config('hashing.bcrypt.rounds', 10);
             if ($rounds < 10) {
                 $this->recordFinding(SecurityFinding::medium(
@@ -116,7 +116,7 @@ trait TestsCryptography
         foreach ($sensitiveFields as $field) {
             $cast = $casts[$field] ?? null;
 
-            if ('encrypted' !== $cast && 'encrypted:array' !== $cast && 'encrypted:collection' !== $cast) {
+            if ($cast !== 'encrypted' && $cast !== 'encrypted:array' && $cast !== 'encrypted:collection') {
                 $this->recordFinding(SecurityFinding::medium(
                     'Sensitive Data Not Encrypted',
                     "Field '{$field}' in {$modelClass} is not encrypted at rest",
@@ -155,7 +155,7 @@ trait TestsCryptography
      */
     protected function assertDatabaseConnectionEncrypted(): void
     {
-        $connections       = config('database.connections', []);
+        $connections = config('database.connections', []);
         $defaultConnection = config('database.default');
 
         $connection = $connections[$defaultConnection] ?? [];
@@ -186,7 +186,7 @@ trait TestsCryptography
         $weakCiphers = ['DES', 'RC4', 'MD5', 'SHA1'];
 
         foreach ($weakCiphers as $weak) {
-            if (false !== stripos($cipher, $weak)) {
+            if (stripos($cipher, $weak) !== false) {
                 $this->recordFinding(SecurityFinding::critical(
                     'Weak Cipher Configured',
                     "Cipher '{$cipher}' contains weak algorithm",

--- a/src/Testing/Traits/TestsInputValidation.php
+++ b/src/Testing/Traits/TestsInputValidation.php
@@ -32,11 +32,11 @@ trait TestsInputValidation
         $payloads = SqlPayloads::getErrorBased();
 
         foreach ($payloads as $payload) {
-            $testParams                   = $parameters;
+            $testParams = $parameters;
             $testParams[$vulnerableParam] = $payload;
 
             $response = $this->$method($uri, $testParams);
-            $content  = $response->getContent();
+            $content = $response->getContent();
 
             if ($this->hasSqlError($content)) {
                 $this->recordFinding(SecurityFinding::critical(
@@ -64,11 +64,11 @@ trait TestsInputValidation
         $payloads = XssPayloads::getBasic();
 
         foreach ($payloads as $payload) {
-            $testParams                   = $parameters;
+            $testParams = $parameters;
             $testParams[$vulnerableParam] = $payload;
 
             $response = $this->$method($uri, $testParams);
-            $content  = $response->getContent();
+            $content = $response->getContent();
 
             // Check if payload is reflected unescaped
             if ($this->isXssPayloadReflected($content, $payload)) {
@@ -97,11 +97,11 @@ trait TestsInputValidation
         $payloads = InjectionPayloads::getCommandInjection();
 
         foreach ($payloads as $payload) {
-            $testParams                   = $parameters;
+            $testParams = $parameters;
             $testParams[$vulnerableParam] = $payload;
 
             $response = $this->$method($uri, $testParams);
-            $content  = $response->getContent();
+            $content = $response->getContent();
 
             if ($this->hasCommandExecutionIndicator($content)) {
                 $this->recordFinding(SecurityFinding::critical(
@@ -137,11 +137,11 @@ trait TestsInputValidation
         ];
 
         foreach ($payloads as $payload) {
-            $testParams                   = $parameters;
+            $testParams = $parameters;
             $testParams[$vulnerableParam] = $payload;
 
             $response = $this->$method($uri, $testParams);
-            $content  = $response->getContent();
+            $content = $response->getContent();
 
             if ($this->hasSensitiveFileContent($content)) {
                 $this->recordFinding(SecurityFinding::critical(
@@ -166,18 +166,18 @@ trait TestsInputValidation
         array $parameters,
         string $vulnerableParam,
     ): void {
-        $payloads           = InjectionPayloads::getLdapInjection();
+        $payloads = InjectionPayloads::getLdapInjection();
         $vulnerabilityFound = false;
 
         foreach ($payloads as $payload) {
-            $testParams                   = $parameters;
+            $testParams = $parameters;
             $testParams[$vulnerableParam] = $payload;
 
             $response = $this->$method($uri, $testParams);
 
             // LDAP injection might result in unexpected success or error patterns
             // Check for wildcard injection (returns all results)
-            if (200 === $response->status() && str_contains($payload, '*')) {
+            if ($response->status() === 200 && str_contains($payload, '*')) {
                 $this->recordFinding(SecurityFinding::high(
                     'Potential LDAP Injection',
                     "Parameter '{$vulnerableParam}' may be vulnerable to LDAP injection with wildcard payload",
@@ -346,7 +346,7 @@ trait TestsInputValidation
         $response = $this->$method($uri, $invalidData);
 
         $this->assertTrue(
-            422 === $response->status() || 400 === $response->status(),
+            $response->status() === 422 || $response->status() === 400,
             "Expected validation error (422/400) for invalid input, got {$response->status()}",
         );
     }

--- a/src/Testing/Traits/TestsSecurityHeaders.php
+++ b/src/Testing/Traits/TestsSecurityHeaders.php
@@ -66,7 +66,7 @@ trait TestsSecurityHeaders
     {
         $header = $response->headers->get('X-Content-Type-Options');
 
-        if ('nosniff' !== $header) {
+        if ($header !== 'nosniff') {
             $this->recordFinding(SecurityFinding::medium(
                 'Missing X-Content-Type-Options Header',
                 'Response does not include X-Content-Type-Options: nosniff',
@@ -243,7 +243,7 @@ trait TestsSecurityHeaders
     {
         $cacheControl = $response->headers->get('Cache-Control');
 
-        $requiredDirectives    = ['no-store', 'no-cache', 'must-revalidate'];
+        $requiredDirectives = ['no-store', 'no-cache', 'must-revalidate'];
         $hasRequiredDirectives = true;
 
         foreach ($requiredDirectives as $directive) {

--- a/src/Testing/Traits/TestsSessionSecurity.php
+++ b/src/Testing/Traits/TestsSessionSecurity.php
@@ -46,7 +46,7 @@ trait TestsSessionSecurity
         }
 
         $sameSite = $sessionConfig['same_site'] ?? null;
-        if (null === $sameSite || 'none' === $sameSite) {
+        if ($sameSite === null || $sameSite === 'none') {
             $this->recordFinding(SecurityFinding::medium(
                 'Session Cookie SameSite Not Strict',
                 'Session cookie SameSite attribute is not set to Strict or Lax',

--- a/src/View/Components/CspNonce.php
+++ b/src/View/Components/CspNonce.php
@@ -28,7 +28,7 @@ class CspNonce extends Component
      */
     public function __construct(?CspPolicyInterface $csp = null)
     {
-        $csp         = $csp ?? app(CspPolicyInterface::class);
+        $csp = $csp ?? app(CspPolicyInterface::class);
         $this->nonce = $csp->getNonce();
     }
 

--- a/tests/Concerns/ValidatesInput.php
+++ b/tests/Concerns/ValidatesInput.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Concerns;
 
+use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Facades\Validator;
 
 trait ValidatesInput
@@ -11,7 +12,7 @@ trait ValidatesInput
     /**
      * Assert that the given value passes the validation rule.
      *
-     * @param  \Illuminate\Contracts\Validation\Rule  $rule
+     * @param  Rule  $rule
      * @param  mixed  $value
      */
     public function assertValidates($rule, $value): void
@@ -23,7 +24,7 @@ trait ValidatesInput
     /**
      * Assert that the given value fails the validation rule.
      *
-     * @param  \Illuminate\Contracts\Validation\Rule  $rule
+     * @param  Rule  $rule
      * @param  mixed  $value
      */
     public function assertFailsValidation($rule, $value): void

--- a/tests/Feature/CheckSecurityConfigurationCommandTest.php
+++ b/tests/Feature/CheckSecurityConfigurationCommandTest.php
@@ -102,9 +102,9 @@ class CheckSecurityConfigurationCommandTest extends TestCase
         // Set up base security configuration
         $app['config']->set('artisanpack.security.security-headers', [
             'Strict-Transport-Security' => 'max-age=31536000; includeSubDomains',
-            'X-Frame-Options'           => 'SAMEORIGIN',
-            'X-Content-Type-Options'    => 'nosniff',
-            'Content-Security-Policy'   => "default-src 'self'",
+            'X-Frame-Options' => 'SAMEORIGIN',
+            'X-Content-Type-Options' => 'nosniff',
+            'Content-Security-Policy' => "default-src 'self'",
         ]);
         $app['config']->set('artisanpack.security.xss.enabled', true);
         $app['config']->set('artisanpack.security.rateLimiting.enabled', true);

--- a/tests/Feature/CspTest.php
+++ b/tests/Feature/CspTest.php
@@ -8,6 +8,7 @@ use ArtisanPackUI\Security\Contracts\CspPolicyInterface;
 use ArtisanPackUI\Security\Http\Middleware\ContentSecurityPolicy;
 use ArtisanPackUI\Security\Models\CspViolationReport;
 use ArtisanPackUI\Security\Services\Csp\CspNonceGenerator;
+use ArtisanPackUI\Security\Services\Csp\CspViolationHandler;
 use ArtisanPackUI\Security\Testing\CspAssertions;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -33,7 +34,7 @@ class CspTest extends TestCase
     #[Test]
     public function it_adds_csp_header_to_response(): void
     {
-        $request    = Request::create('/test', 'GET');
+        $request = Request::create('/test', 'GET');
         $middleware = app(ContentSecurityPolicy::class);
 
         $response = $middleware->handle($request, function () {
@@ -48,7 +49,7 @@ class CspTest extends TestCase
     {
         Config::set('artisanpack.security.csp.reportOnly', true);
 
-        $request    = Request::create('/test', 'GET');
+        $request = Request::create('/test', 'GET');
         $middleware = app(ContentSecurityPolicy::class);
 
         $response = $middleware->handle($request, function () {
@@ -64,7 +65,7 @@ class CspTest extends TestCase
     {
         Config::set('artisanpack.security.csp.enabled', false);
 
-        $request    = Request::create('/test', 'GET');
+        $request = Request::create('/test', 'GET');
         $middleware = app(ContentSecurityPolicy::class);
 
         $response = $middleware->handle($request, function () {
@@ -78,7 +79,7 @@ class CspTest extends TestCase
     #[Test]
     public function it_includes_nonce_in_csp_header(): void
     {
-        $request    = Request::create('/test', 'GET');
+        $request = Request::create('/test', 'GET');
         $middleware = app(ContentSecurityPolicy::class);
 
         $response = $middleware->handle($request, function () {
@@ -135,7 +136,7 @@ class CspTest extends TestCase
     {
         Config::set('artisanpack.security.csp.excludedRoutes', ['api/*']);
 
-        $request    = Request::create('/api/users', 'GET');
+        $request = Request::create('/api/users', 'GET');
         $middleware = app(ContentSecurityPolicy::class);
 
         $response = $middleware->handle($request, function () {
@@ -164,13 +165,13 @@ class CspTest extends TestCase
     public function it_validates_violation_reports(): void
     {
         // Test the validation logic without database
-        $handler = app(\ArtisanPackUI\Security\Services\Csp\CspViolationHandler::class);
+        $handler = app(CspViolationHandler::class);
 
         // Valid report should be accepted
         $validReport = [
             'csp-report' => [
-                'document-uri'       => 'https://example.com/page',
-                'blocked-uri'        => 'https://evil.com/script.js',
+                'document-uri' => 'https://example.com/page',
+                'blocked-uri' => 'https://evil.com/script.js',
                 'violated-directive' => 'script-src',
             ],
         ];
@@ -186,7 +187,7 @@ class CspTest extends TestCase
     #[Test]
     public function it_rejects_invalid_violation_reports(): void
     {
-        $handler = app(\ArtisanPackUI\Security\Services\Csp\CspViolationHandler::class);
+        $handler = app(CspViolationHandler::class);
 
         Config::set('artisanpack.security.csp.reporting.storeViolations', false);
 
@@ -294,19 +295,19 @@ class CspTest extends TestCase
     public function it_generates_fingerprint_for_deduplication(): void
     {
         $report1 = [
-            'document-uri'       => 'https://example.com/page',
-            'blocked-uri'        => 'https://evil.com/script.js',
+            'document-uri' => 'https://example.com/page',
+            'blocked-uri' => 'https://evil.com/script.js',
             'violated-directive' => 'script-src',
-            'source-file'        => 'script.js',
-            'line-number'        => 10,
+            'source-file' => 'script.js',
+            'line-number' => 10,
         ];
 
         $report2 = [
-            'document-uri'       => 'https://example.com/page',
-            'blocked-uri'        => 'https://evil.com/script.js',
+            'document-uri' => 'https://example.com/page',
+            'blocked-uri' => 'https://evil.com/script.js',
             'violated-directive' => 'script-src',
-            'source-file'        => 'script.js',
-            'line-number'        => 10,
+            'source-file' => 'script.js',
+            'line-number' => 10,
         ];
 
         $fingerprint1 = CspViolationReport::generateFingerprint($report1);
@@ -319,14 +320,14 @@ class CspTest extends TestCase
     public function it_generates_different_fingerprints_for_different_reports(): void
     {
         $report1 = [
-            'document-uri'       => 'https://example.com/page1',
-            'blocked-uri'        => 'https://evil.com/script1.js',
+            'document-uri' => 'https://example.com/page1',
+            'blocked-uri' => 'https://evil.com/script1.js',
             'violated-directive' => 'script-src',
         ];
 
         $report2 = [
-            'document-uri'       => 'https://example.com/page2',
-            'blocked-uri'        => 'https://evil.com/script2.js',
+            'document-uri' => 'https://example.com/page2',
+            'blocked-uri' => 'https://evil.com/script2.js',
             'violated-directive' => 'script-src',
         ];
 

--- a/tests/Feature/RateLimitingTest.php
+++ b/tests/Feature/RateLimitingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use ArtisanPackUI\Security\SecurityServiceProvider;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
@@ -37,7 +38,7 @@ class RateLimitingTest extends TestCase
             return 'Success';
         })->middleware('throttle:test');
 
-        $user     = new User;
+        $user = new User;
         $user->id = 1;
         $this->actingAs($user);
 
@@ -55,7 +56,7 @@ class RateLimitingTest extends TestCase
     protected function getPackageProviders($app): array
     {
         return [
-            \ArtisanPackUI\Security\SecurityServiceProvider::class,
+            SecurityServiceProvider::class,
         ];
     }
 
@@ -64,7 +65,7 @@ class RateLimitingTest extends TestCase
         // Enable rate limiting and define a test route with a limiter
         Config::set('artisanpack.security.rateLimiting.enabled', true);
         Config::set('artisanpack.security.rateLimiting.limiters.test', [
-            'maxAttempts'  => 3,
+            'maxAttempts' => 3,
             'decayMinutes' => 1,
         ]);
     }

--- a/tests/Feature/SecurityHeadersMiddlewareTest.php
+++ b/tests/Feature/SecurityHeadersMiddlewareTest.php
@@ -17,13 +17,13 @@ class SecurityHeadersMiddlewareTest extends TestCase
     public function it_adds_configured_security_headers_to_the_response(): void
     {
         $headers = [
-            'X-Frame-Options'         => 'DENY',
-            'X-Content-Type-Options'  => 'nosniff',
+            'X-Frame-Options' => 'DENY',
+            'X-Content-Type-Options' => 'nosniff',
             'Content-Security-Policy' => "default-src 'none'",
         ];
         Config::set('artisanpack.security.security-headers', $headers);
 
-        $request    = new Request;
+        $request = new Request;
         $middleware = new SecurityHeadersMiddleware;
 
         $response = $middleware->handle($request, function () {
@@ -39,13 +39,13 @@ class SecurityHeadersMiddlewareTest extends TestCase
     public function it_does_not_add_headers_that_are_null_or_empty(): void
     {
         $headers = [
-            'X-Frame-Options'        => 'SAMEORIGIN',
+            'X-Frame-Options' => 'SAMEORIGIN',
             'X-Content-Type-Options' => null, // This should be ignored
-            'Referrer-Policy'        => '', // This should be ignored
+            'Referrer-Policy' => '', // This should be ignored
         ];
         Config::set('artisanpack.security.security-headers', $headers);
 
-        $request    = new Request;
+        $request = new Request;
         $middleware = new SecurityHeadersMiddleware;
 
         $response = $middleware->handle($request, function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+use Tests\TestCase;
 
 /*
 |--------------------------------------------------------------------------
@@ -13,7 +14,7 @@ declare(strict_types=1);
 |
 */
 
-pest()->extend(Tests\TestCase::class)
+pest()->extend(TestCase::class)
     // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in(__DIR__);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,9 +23,9 @@ class TestCase extends Orchestra
         $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
         $app['config']->set('database.default', 'testing');
         $app['config']->set('database.connections.testing', [
-            'driver'   => 'sqlite',
+            'driver' => 'sqlite',
             'database' => ':memory:',
-            'prefix'   => '',
+            'prefix' => '',
         ]);
 
         // Create the users table that the package migrations depend on

--- a/tests/Unit/CspPresetsTest.php
+++ b/tests/Unit/CspPresetsTest.php
@@ -19,7 +19,7 @@ class CspPresetsTest extends TestCase
     public function livewire_preset_uses_strict_dynamic(): void
     {
         $builder = new CspPolicyBuilder;
-        $preset  = new LivewirePreset;
+        $preset = new LivewirePreset;
 
         $preset->apply($builder, $this->testNonce);
         $policy = $builder->build();
@@ -31,7 +31,7 @@ class CspPresetsTest extends TestCase
     public function livewire_preset_includes_nonce(): void
     {
         $builder = new CspPolicyBuilder;
-        $preset  = new LivewirePreset;
+        $preset = new LivewirePreset;
 
         $preset->apply($builder, $this->testNonce);
         $policy = $builder->build();
@@ -43,7 +43,7 @@ class CspPresetsTest extends TestCase
     public function livewire_preset_blocks_objects(): void
     {
         $builder = new CspPolicyBuilder;
-        $preset  = new LivewirePreset;
+        $preset = new LivewirePreset;
 
         $preset->apply($builder, $this->testNonce);
         $policy = $builder->build();
@@ -55,7 +55,7 @@ class CspPresetsTest extends TestCase
     public function strict_preset_blocks_by_default(): void
     {
         $builder = new CspPolicyBuilder;
-        $preset  = new StrictPreset;
+        $preset = new StrictPreset;
 
         $preset->apply($builder, $this->testNonce);
         $policy = $builder->build();
@@ -67,7 +67,7 @@ class CspPresetsTest extends TestCase
     public function strict_preset_blocks_objects(): void
     {
         $builder = new CspPolicyBuilder;
-        $preset  = new StrictPreset;
+        $preset = new StrictPreset;
 
         $preset->apply($builder, $this->testNonce);
         $policy = $builder->build();
@@ -79,7 +79,7 @@ class CspPresetsTest extends TestCase
     public function strict_preset_requires_nonce_for_scripts(): void
     {
         $builder = new CspPolicyBuilder;
-        $preset  = new StrictPreset;
+        $preset = new StrictPreset;
 
         $preset->apply($builder, $this->testNonce);
         $policy = $builder->build();
@@ -91,7 +91,7 @@ class CspPresetsTest extends TestCase
     public function relaxed_preset_allows_self(): void
     {
         $builder = new CspPolicyBuilder;
-        $preset  = new RelaxedPreset;
+        $preset = new RelaxedPreset;
 
         $preset->apply($builder, $this->testNonce);
         $policy = $builder->build();
@@ -103,7 +103,7 @@ class CspPresetsTest extends TestCase
     public function relaxed_preset_uses_strict_dynamic(): void
     {
         $builder = new CspPolicyBuilder;
-        $preset  = new RelaxedPreset;
+        $preset = new RelaxedPreset;
 
         $preset->apply($builder, $this->testNonce);
         $policy = $builder->build();
@@ -116,7 +116,7 @@ class CspPresetsTest extends TestCase
     public function relaxed_preset_allows_https(): void
     {
         $builder = new CspPolicyBuilder;
-        $preset  = new RelaxedPreset;
+        $preset = new RelaxedPreset;
 
         $preset->apply($builder, $this->testNonce);
         $policy = $builder->build();
@@ -128,8 +128,8 @@ class CspPresetsTest extends TestCase
     public function presets_can_return_their_name(): void
     {
         $livewire = new LivewirePreset;
-        $strict   = new StrictPreset;
-        $relaxed  = new RelaxedPreset;
+        $strict = new StrictPreset;
+        $relaxed = new RelaxedPreset;
 
         $this->assertEquals('livewire', $livewire->getName());
         $this->assertEquals('strict', $strict->getName());
@@ -140,8 +140,8 @@ class CspPresetsTest extends TestCase
     public function presets_can_return_their_description(): void
     {
         $livewire = new LivewirePreset;
-        $strict   = new StrictPreset;
-        $relaxed  = new RelaxedPreset;
+        $strict = new StrictPreset;
+        $relaxed = new RelaxedPreset;
 
         $this->assertNotEmpty($livewire->getDescription());
         $this->assertNotEmpty($strict->getDescription());

--- a/tests/Unit/SanitizeTest.php
+++ b/tests/Unit/SanitizeTest.php
@@ -42,12 +42,12 @@ test('sanitize strings', function (): void {
 
 test('sanitize arrays', function (): void {
     $arrayToTest = [
-        'array_key'       => 'array_value',
+        'array_key' => 'array_value',
         'wrong array key' => '<p>wrong array value</p>',
     ];
 
     $arrayToCheck = [
-        'array_key'       => 'array_value',
+        'array_key' => 'array_value',
         'wrong array key' => 'wrong array value',
     ];
 

--- a/tests/Unit/Testing/CiCd/GitHubActionsIntegrationTest.php
+++ b/tests/Unit/Testing/CiCd/GitHubActionsIntegrationTest.php
@@ -88,13 +88,13 @@ class GitHubActionsIntegrationTest extends TestCase
         ];
 
         $summary = [
-            'total'      => 2,
+            'total' => 2,
             'bySeverity' => [
                 'critical' => 1,
-                'high'     => 1,
-                'medium'   => 0,
-                'low'      => 0,
-                'info'     => 0,
+                'high' => 1,
+                'medium' => 0,
+                'low' => 0,
+                'info' => 0,
             ],
         ];
 
@@ -113,11 +113,11 @@ class GitHubActionsIntegrationTest extends TestCase
         ];
 
         $summary = [
-            'total'      => 1,
+            'total' => 1,
             'bySeverity' => [
                 'critical' => 0,
-                'high'     => 1,
-                'medium'   => 0,
+                'high' => 1,
+                'medium' => 0,
             ],
         ];
 
@@ -133,11 +133,11 @@ class GitHubActionsIntegrationTest extends TestCase
         ];
 
         $summary = [
-            'total'      => 1,
+            'total' => 1,
             'bySeverity' => [
                 'critical' => 0,
-                'high'     => 0,
-                'medium'   => 1,
+                'high' => 0,
+                'medium' => 1,
             ],
         ];
 
@@ -154,7 +154,7 @@ class GitHubActionsIntegrationTest extends TestCase
         }
 
         $summary = [
-            'total'      => 7,
+            'total' => 7,
             'bySeverity' => ['medium' => 7],
         ];
 
@@ -169,7 +169,7 @@ class GitHubActionsIntegrationTest extends TestCase
     public function test_summary_handles_empty_findings(): void
     {
         $summary = [
-            'total'      => 0,
+            'total' => 0,
             'bySeverity' => [],
         ];
 

--- a/tests/Unit/Testing/CiCd/SecurityGateTest.php
+++ b/tests/Unit/Testing/CiCd/SecurityGateTest.php
@@ -21,7 +21,7 @@ class SecurityGateTest extends TestCase
 
     public function test_passes_with_no_findings(): void
     {
-        $gate   = new SecurityGate;
+        $gate = new SecurityGate;
         $result = $gate->evaluate([]);
 
         $this->assertTrue($result->passed);
@@ -30,7 +30,7 @@ class SecurityGateTest extends TestCase
 
     public function test_fails_with_critical_finding(): void
     {
-        $gate     = new SecurityGate(maxCritical: 0);
+        $gate = new SecurityGate(maxCritical: 0);
         $findings = [
             SecurityFinding::critical('Critical Issue', 'Description', 'test'),
         ];
@@ -44,7 +44,7 @@ class SecurityGateTest extends TestCase
 
     public function test_passes_with_critical_finding_when_threshold_allows(): void
     {
-        $gate     = new SecurityGate(maxCritical: 1);
+        $gate = new SecurityGate(maxCritical: 1);
         $findings = [
             SecurityFinding::critical('Critical Issue', 'Description', 'test'),
         ];
@@ -56,7 +56,7 @@ class SecurityGateTest extends TestCase
 
     public function test_fails_with_high_finding_exceeding_threshold(): void
     {
-        $gate     = new SecurityGate(maxHigh: 0);
+        $gate = new SecurityGate(maxHigh: 0);
         $findings = [
             SecurityFinding::high('High Issue', 'Description', 'test'),
         ];
@@ -69,7 +69,7 @@ class SecurityGateTest extends TestCase
 
     public function test_fails_with_medium_findings_exceeding_threshold(): void
     {
-        $gate     = new SecurityGate(maxMedium: 2);
+        $gate = new SecurityGate(maxMedium: 2);
         $findings = [
             SecurityFinding::medium('Medium 1', 'Description', 'test'),
             SecurityFinding::medium('Medium 2', 'Description', 'test'),
@@ -84,7 +84,7 @@ class SecurityGateTest extends TestCase
 
     public function test_ignores_low_findings(): void
     {
-        $gate     = new SecurityGate;
+        $gate = new SecurityGate;
         $findings = [
             SecurityFinding::low('Low Issue 1', 'Description', 'test'),
             SecurityFinding::low('Low Issue 2', 'Description', 'test'),
@@ -98,7 +98,7 @@ class SecurityGateTest extends TestCase
 
     public function test_ignores_info_findings(): void
     {
-        $gate     = new SecurityGate;
+        $gate = new SecurityGate;
         $findings = [
             SecurityFinding::info('Info 1', 'Description', 'test'),
             SecurityFinding::info('Info 2', 'Description', 'test'),
@@ -276,7 +276,7 @@ class SecurityGateTest extends TestCase
 
     public function test_summary_contains_correct_counts(): void
     {
-        $gate     = new SecurityGate(maxCritical: 5, maxHigh: 5, maxMedium: 20);
+        $gate = new SecurityGate(maxCritical: 5, maxHigh: 5, maxMedium: 20);
         $findings = [
             SecurityFinding::critical('Critical 1', 'Desc', 'test'),
             SecurityFinding::high('High 1', 'Desc', 'test'),

--- a/tests/Unit/Testing/PenetrationTesting/AttackResultsTest.php
+++ b/tests/Unit/Testing/PenetrationTesting/AttackResultsTest.php
@@ -75,7 +75,7 @@ class AttackResultsTest extends TestCase
     public function test_is_critical(): void
     {
         $critical = AttackResult::vulnerable('Test', 'critical');
-        $high     = AttackResult::vulnerable('Test', 'high');
+        $high = AttackResult::vulnerable('Test', 'high');
 
         $this->assertTrue($critical->isCritical());
         $this->assertFalse($high->isCritical());
@@ -83,7 +83,7 @@ class AttackResultsTest extends TestCase
 
     public function test_is_high(): void
     {
-        $high   = AttackResult::vulnerable('Test', 'high');
+        $high = AttackResult::vulnerable('Test', 'high');
         $medium = AttackResult::vulnerable('Test', 'medium');
 
         $this->assertTrue($high->isHigh());
@@ -93,9 +93,9 @@ class AttackResultsTest extends TestCase
     public function test_is_blocking(): void
     {
         $critical = AttackResult::vulnerable('Test', 'critical');
-        $high     = AttackResult::vulnerable('Test', 'high');
-        $medium   = AttackResult::vulnerable('Test', 'medium');
-        $notVuln  = AttackResult::notVulnerable('Test');
+        $high = AttackResult::vulnerable('Test', 'high');
+        $medium = AttackResult::vulnerable('Test', 'medium');
+        $notVuln = AttackResult::notVulnerable('Test');
 
         $this->assertTrue($critical->isBlocking());
         $this->assertTrue($high->isBlocking());
@@ -131,7 +131,7 @@ class AttackResultsTest extends TestCase
     public function test_can_add_result(): void
     {
         $results = new AttackResults;
-        $result  = AttackResult::notVulnerable('XSS');
+        $result = AttackResult::notVulnerable('XSS');
 
         $results->add($result);
 

--- a/tests/Unit/Testing/Performance/BenchmarkResultTest.php
+++ b/tests/Unit/Testing/Performance/BenchmarkResultTest.php
@@ -12,16 +12,16 @@ class BenchmarkResultTest extends TestCase
     public function test_can_create_benchmark_result(): void
     {
         $withSecurity = [
-            'mean'   => 10.5,
-            'min'    => 8.0,
-            'max'    => 15.0,
+            'mean' => 10.5,
+            'min' => 8.0,
+            'max' => 15.0,
             'stddev' => 2.5,
         ];
 
         $withoutSecurity = [
-            'mean'   => 5.0,
-            'min'    => 4.0,
-            'max'    => 7.0,
+            'mean' => 5.0,
+            'min' => 4.0,
+            'max' => 7.0,
             'stddev' => 1.0,
         ];
 

--- a/tests/Unit/Testing/Performance/ImpactAnalyzerTest.php
+++ b/tests/Unit/Testing/Performance/ImpactAnalyzerTest.php
@@ -57,7 +57,7 @@ class ImpactAnalyzerTest extends TestCase
         ];
 
         $analyzer = new ImpactAnalyzer($results);
-        $summary  = $analyzer->getSummary();
+        $summary = $analyzer->getSummary();
 
         $this->assertEquals(3, $summary['total_benchmarks']);
         $this->assertEquals(2, $summary['acceptable']);
@@ -73,7 +73,7 @@ class ImpactAnalyzerTest extends TestCase
         ];
 
         $analyzer = new ImpactAnalyzer($results);
-        $summary  = $analyzer->getSummary();
+        $summary = $analyzer->getSummary();
 
         // 2 out of 3 pass = 66.67%
         $this->assertEqualsWithDelta(66.67, $summary['pass_rate'], 0.01);
@@ -98,7 +98,7 @@ class ImpactAnalyzerTest extends TestCase
         );
 
         $analyzer = new ImpactAnalyzer([$acceptable, $unacceptable]);
-        $summary  = $analyzer->getSummary();
+        $summary = $analyzer->getSummary();
 
         // Average of 5% and 150% = 77.5%
         $this->assertEqualsWithDelta(77.5, $summary['average_overhead'], 0.1);
@@ -111,7 +111,7 @@ class ImpactAnalyzerTest extends TestCase
             $this->createUnacceptableResult('Hashing'),
         ];
 
-        $analyzer        = new ImpactAnalyzer($results);
+        $analyzer = new ImpactAnalyzer($results);
         $recommendations = $analyzer->getRecommendations();
 
         $this->assertArrayHasKey('Hashing', $recommendations);
@@ -125,7 +125,7 @@ class ImpactAnalyzerTest extends TestCase
             $this->createAcceptableResult('Test 2'),
         ];
 
-        $analyzer        = new ImpactAnalyzer($results);
+        $analyzer = new ImpactAnalyzer($results);
         $recommendations = $analyzer->getRecommendations();
 
         $this->assertEmpty($recommendations);
@@ -134,7 +134,7 @@ class ImpactAnalyzerTest extends TestCase
     public function test_handles_empty_results(): void
     {
         $analyzer = new ImpactAnalyzer([]);
-        $summary  = $analyzer->getSummary();
+        $summary = $analyzer->getSummary();
 
         $this->assertEquals(0, $summary['total_benchmarks']);
         $this->assertEquals(0, $summary['acceptable']);
@@ -193,7 +193,7 @@ class ImpactAnalyzerTest extends TestCase
         ];
 
         $analyzer = new ImpactAnalyzer($results);
-        $summary  = $analyzer->getSummary();
+        $summary = $analyzer->getSummary();
 
         $this->assertEquals(100.0, $summary['pass_rate']);
     }
@@ -218,7 +218,7 @@ class ImpactAnalyzerTest extends TestCase
         ];
 
         $analyzer = new ImpactAnalyzer($results);
-        $export   = $analyzer->toArray();
+        $export = $analyzer->toArray();
 
         $this->assertArrayHasKey('summary', $export);
         $this->assertArrayHasKey('recommendations', $export);

--- a/tests/Unit/Testing/Reporting/ReportFormatsTest.php
+++ b/tests/Unit/Testing/Reporting/ReportFormatsTest.php
@@ -31,16 +31,16 @@ class ReportFormatsTest extends TestCase
         ];
 
         $this->sampleSummary = [
-            'total'      => 3,
+            'total' => 3,
             'bySeverity' => [
                 'critical' => 1,
-                'high'     => 1,
-                'medium'   => 1,
-                'low'      => 0,
-                'info'     => 0,
+                'high' => 1,
+                'medium' => 1,
+                'low' => 0,
+                'info' => 0,
             ],
             'byCategory' => [
-                'A03:2021-Injection'                 => 2,
+                'A03:2021-Injection' => 2,
                 'A05:2021-Security Misconfiguration' => 1,
             ],
         ];
@@ -48,7 +48,7 @@ class ReportFormatsTest extends TestCase
         $this->sampleMetadata = [
             'generatedAt' => now()->toIso8601String(),
             'projectName' => 'Test Project',
-            'version'     => '1.0.0',
+            'version' => '1.0.0',
         ];
     }
 
@@ -64,8 +64,8 @@ class ReportFormatsTest extends TestCase
 
     public function test_json_format_contains_findings(): void
     {
-        $format  = new JsonReportFormat;
-        $output  = $format->format($this->sampleFindings, $this->sampleMetadata, $this->sampleSummary);
+        $format = new JsonReportFormat;
+        $output = $format->format($this->sampleFindings, $this->sampleMetadata, $this->sampleSummary);
         $decoded = json_decode($output, true);
 
         $this->assertArrayHasKey('findings', $decoded);
@@ -74,8 +74,8 @@ class ReportFormatsTest extends TestCase
 
     public function test_json_format_contains_summary(): void
     {
-        $format  = new JsonReportFormat;
-        $output  = $format->format($this->sampleFindings, $this->sampleMetadata, $this->sampleSummary);
+        $format = new JsonReportFormat;
+        $output = $format->format($this->sampleFindings, $this->sampleMetadata, $this->sampleSummary);
         $decoded = json_decode($output, true);
 
         $this->assertArrayHasKey('summary', $decoded);
@@ -84,8 +84,8 @@ class ReportFormatsTest extends TestCase
 
     public function test_json_format_contains_metadata(): void
     {
-        $format  = new JsonReportFormat;
-        $output  = $format->format($this->sampleFindings, $this->sampleMetadata, $this->sampleSummary);
+        $format = new JsonReportFormat;
+        $output = $format->format($this->sampleFindings, $this->sampleMetadata, $this->sampleSummary);
         $decoded = json_decode($output, true);
 
         $this->assertArrayHasKey('metadata', $decoded);
@@ -185,8 +185,8 @@ class ReportFormatsTest extends TestCase
 
     public function test_sarif_format_has_correct_version(): void
     {
-        $format  = new SarifReportFormat;
-        $output  = $format->format($this->sampleFindings, $this->sampleMetadata, $this->sampleSummary);
+        $format = new SarifReportFormat;
+        $output = $format->format($this->sampleFindings, $this->sampleMetadata, $this->sampleSummary);
         $decoded = json_decode($output, true);
 
         $this->assertEquals('2.1.0', $decoded['version']);
@@ -195,8 +195,8 @@ class ReportFormatsTest extends TestCase
 
     public function test_sarif_format_contains_runs(): void
     {
-        $format  = new SarifReportFormat;
-        $output  = $format->format($this->sampleFindings, $this->sampleMetadata, $this->sampleSummary);
+        $format = new SarifReportFormat;
+        $output = $format->format($this->sampleFindings, $this->sampleMetadata, $this->sampleSummary);
         $decoded = json_decode($output, true);
 
         $this->assertArrayHasKey('runs', $decoded);
@@ -205,8 +205,8 @@ class ReportFormatsTest extends TestCase
 
     public function test_sarif_format_contains_results(): void
     {
-        $format  = new SarifReportFormat;
-        $output  = $format->format($this->sampleFindings, $this->sampleMetadata, $this->sampleSummary);
+        $format = new SarifReportFormat;
+        $output = $format->format($this->sampleFindings, $this->sampleMetadata, $this->sampleSummary);
         $decoded = json_decode($output, true);
 
         $results = $decoded['runs'][0]['results'] ?? [];

--- a/tests/Unit/Testing/Reporting/SecurityReportGeneratorTest.php
+++ b/tests/Unit/Testing/Reporting/SecurityReportGeneratorTest.php
@@ -14,7 +14,7 @@ class SecurityReportGeneratorTest extends TestCase
     public function test_can_add_finding(): void
     {
         $generator = new SecurityReportGenerator;
-        $finding   = SecurityFinding::high('Test Finding', 'Description', 'test');
+        $finding = SecurityFinding::high('Test Finding', 'Description', 'test');
 
         $generator->addFinding($finding);
         $findings = $generator->getFindings();
@@ -37,7 +37,7 @@ class SecurityReportGeneratorTest extends TestCase
     public function test_can_add_findings_array(): void
     {
         $generator = new SecurityReportGenerator;
-        $findings  = [
+        $findings = [
             SecurityFinding::high('Finding 1', 'Desc', 'cat'),
             SecurityFinding::medium('Finding 2', 'Desc', 'cat'),
         ];
@@ -142,7 +142,7 @@ class SecurityReportGeneratorTest extends TestCase
         $generator = new SecurityReportGenerator;
         $generator->addFinding(SecurityFinding::high('Test', 'Desc', 'cat'));
 
-        $path   = sys_get_temp_dir().'/security-report-test.json';
+        $path = sys_get_temp_dir().'/security-report-test.json';
         $result = $generator->saveToFile($path, 'json');
 
         $this->assertTrue($result);
@@ -210,7 +210,7 @@ class SecurityReportGeneratorTest extends TestCase
     {
         $generator = new SecurityReportGenerator;
 
-        $report  = $generator->generate('json');
+        $report = $generator->generate('json');
         $decoded = json_decode($report, true);
 
         $this->assertEmpty($decoded['findings']);
@@ -223,7 +223,7 @@ class SecurityReportGeneratorTest extends TestCase
         $generator->withMetadata(['customField' => 'customValue']);
         $generator->addFinding(SecurityFinding::high('Test', 'Desc', 'cat'));
 
-        $report  = $generator->generate('json');
+        $report = $generator->generate('json');
         $decoded = json_decode($report, true);
 
         $this->assertArrayHasKey('metadata', $decoded);

--- a/tests/Unit/Testing/SecurityFindingTest.php
+++ b/tests/Unit/Testing/SecurityFindingTest.php
@@ -124,15 +124,15 @@ class SecurityFindingTest extends TestCase
     public function test_creates_from_vulnerability_array(): void
     {
         $data = [
-            'id'          => 'from-array-001',
-            'title'       => 'From Array',
+            'id' => 'from-array-001',
+            'title' => 'From Array',
             'description' => 'Created from array',
-            'severity'    => SecurityFinding::SEVERITY_LOW,
-            'category'    => 'array-category',
-            'location'    => 'test/location.php',
+            'severity' => SecurityFinding::SEVERITY_LOW,
+            'category' => 'array-category',
+            'location' => 'test/location.php',
             'remediation' => 'Array recommendation',
-            'evidence'    => 'Some evidence',
-            'metadata'    => ['source' => 'array'],
+            'evidence' => 'Some evidence',
+            'metadata' => ['source' => 'array'],
         ];
 
         $finding = SecurityFinding::fromVulnerability($data);
@@ -156,7 +156,7 @@ class SecurityFindingTest extends TestCase
     public function test_is_critical(): void
     {
         $critical = SecurityFinding::critical('Test', 'Desc', 'cat');
-        $high     = SecurityFinding::high('Test', 'Desc', 'cat');
+        $high = SecurityFinding::high('Test', 'Desc', 'cat');
 
         $this->assertTrue($critical->isCritical());
         $this->assertFalse($high->isCritical());
@@ -164,7 +164,7 @@ class SecurityFindingTest extends TestCase
 
     public function test_is_high(): void
     {
-        $high   = SecurityFinding::high('Test', 'Desc', 'cat');
+        $high = SecurityFinding::high('Test', 'Desc', 'cat');
         $medium = SecurityFinding::medium('Test', 'Desc', 'cat');
 
         $this->assertTrue($high->isHigh());
@@ -174,8 +174,8 @@ class SecurityFindingTest extends TestCase
     public function test_is_blocking(): void
     {
         $critical = SecurityFinding::critical('Test', 'Desc', 'cat');
-        $high     = SecurityFinding::high('Test', 'Desc', 'cat');
-        $medium   = SecurityFinding::medium('Test', 'Desc', 'cat');
+        $high = SecurityFinding::high('Test', 'Desc', 'cat');
+        $medium = SecurityFinding::medium('Test', 'Desc', 'cat');
 
         $this->assertTrue($critical->isBlocking());
         $this->assertTrue($high->isBlocking());
@@ -185,10 +185,10 @@ class SecurityFindingTest extends TestCase
     public function test_severity_order(): void
     {
         $critical = SecurityFinding::critical('Test', 'Desc', 'cat');
-        $high     = SecurityFinding::high('Test', 'Desc', 'cat');
-        $medium   = SecurityFinding::medium('Test', 'Desc', 'cat');
-        $low      = SecurityFinding::low('Test', 'Desc', 'cat');
-        $info     = SecurityFinding::info('Test', 'Desc', 'cat');
+        $high = SecurityFinding::high('Test', 'Desc', 'cat');
+        $medium = SecurityFinding::medium('Test', 'Desc', 'cat');
+        $low = SecurityFinding::low('Test', 'Desc', 'cat');
+        $info = SecurityFinding::info('Test', 'Desc', 'cat');
 
         $this->assertEquals(0, $critical->getSeverityOrder());
         $this->assertEquals(1, $high->getSeverityOrder());


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.0.2
- **Release Date:** 2026-06-09
- **Release Type:** Patch
- **Release Branch:** `release/2.0.2`
- **Target Branch:** `main`

## Release Summary

Patch release adding Laravel 13 support to the core security package without dropping Laravel 10/11/12 or raising the PHP floor for users staying on older Laravel. Also restores Lint CI to green via a Pint sweep of pre-existing style drift.

## Changelog

### Added

- Laravel 13 support. Widened `illuminate/support` to `^10.0|^11.0|^12.0|^13.0`. Laravel 13 is only selectable on PHP 8.3+ per its own framework constraint; users on Laravel 10/11/12 are unaffected.

### Changed

- Widened `orchestra/testbench` dev requirement to `^10.2|^11.0` so package tests can install against Laravel 13.
- Swept the package through Laravel Pint to bring it back in line with the configured code style (no behavioral changes).

### Deprecated

- None

### Removed

- None

### Fixed

- None

### Security

- None

## Issues and Pull Requests

**Issues Fixed:**
- Closes #44

**Related PRs:**
- #45 (Laravel 13 support)

## Breaking Changes

- [x] No breaking changes

## Testing Checklist

- [x] All automated tests passing (255 tests, 491 assertions)
- [x] Security scan completed (composer audit: 0 vulnerabilities)

## Documentation Checklist

- [x] CHANGELOG updated
- [x] README updated
- [x] API documentation updated (docs/installation/requirements.md, docs/faq.md, docs/advanced/video-tutorials.md)

## Pre-Release Checklist

- [x] Version number updated (composer.json: 2.0.1 → 2.0.2)
- [x] Release branch updated: `release/2.0.2`
- [x] Dependencies updated and tested (composer.lock in sync)
- [x] Lint passing (Pint clean across the package)

## Notes

The Pint sweep touched ~85 files but is purely formatting — yoda style, operator spacing, import ordering, fully-qualified strict types, etc. No logic changes. This was needed because Lint CI was failing on `release/2.0.2` from drift accumulated before this release.

---

**Release Manager:** @ViewFromTheBox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Laravel 13 (requires PHP 8.3+).

* **Documentation**
  * Updated installation requirements, FAQ, and video tutorial prerequisites to include Laravel 12.x and 13.x.

* **Chores**
  * Package version bumped to 2.0.2.
  * Code-style sweep and formatting standardization across the codebase.
  * Minor configuration formatting updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->