### PR TITLE
feat: add extension hooks for sanitize, escape, kses, and CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ap.security.csp.violationHandled` action — fires at the end of `CspViolationHandler::handle()` on stored violations with `(CspViolationReport $report)`.
   - See the README "Hooks" section for full payload details and examples.
 
-### Changed
+### Fixed
 
-- `Security::sanitizeInt()` and `Security::sanitizeFloat()` now cast the filtered value back to `int`/`float` before returning, matching their declared return types even when a filter subscriber returns a different numeric shape.
+- `Security::sanitizeFloat()` was declared to return `float` but returned the raw `number_format()` string, which raised a `TypeError` under `strict_types=1` any time the method was actually called. The result is now explicitly cast to `float` before return.
 
 ## [2.0.2] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Extension hooks powered by `artisanpack-ui/hooks` (^1.2):
+  - `ap.security.sanitizedInput` filter — wraps every `Security::sanitize*` return with `(mixed $value, string $type, mixed $original)`.
+  - `ap.security.escapedOutput` filter — wraps every `Security::esc*` return with `(string $value, string $context, string $original)`.
+  - `ap.security.ksesAllowedTags` filter — receives `(array $allowedTags)` from `Security::kses()`; a non-empty return overrides htmLawed's element whitelist for the call.
+  - `ap.security.csp.directives` filter — fires inside `CspPolicyService::getPolicy()` with `(array $directives, Request $request)`, letting host apps mutate the directive array before it is serialized.
+  - `ap.security.csp.violationHandled` action — fires at the end of `CspViolationHandler::handle()` on stored violations with `(CspViolationReport $report)`.
+  - See the README "Hooks" section for full payload details and examples.
+
+### Changed
+
+- `Security::sanitizeInt()` and `Security::sanitizeFloat()` now cast the filtered value back to `int`/`float` before returning, matching their declared return types even when a filter subscriber returns a different numeric shape.
+
 ## [2.0.2] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,6 +76,36 @@ Route::middleware('api.rate_limit:api')->group(function () {
 </script>
 ```
 
+## Hooks
+
+The package fires a small set of [`artisanpack-ui/hooks`](https://github.com/ArtisanPack-UI/hooks) filters and actions so host apps can extend sanitization, escaping, KSES, and CSP handling without subclassing. Register subscribers with `addFilter()` / `addAction()`.
+
+| Hook | Type | When it fires | Payload |
+|---|---|---|---|
+| `ap.security.sanitizedInput` | filter | Wraps the return of every `Security::sanitize*` method (email, url, filename, password, int, date, datetime, float, array, text) | `(mixed $value, string $type, mixed $original)` — `$type` is the sanitizer name (`email`, `url`, `filename`, `password`, `int`, `date`, `datetime`, `float`, `array`, `text`) |
+| `ap.security.escapedOutput` | filter | Wraps the return of every `Security::esc*` method | `(string $value, string $context, string $original)` — `$context` is one of `html`, `attr`, `url`, `js`, `css` |
+| `ap.security.ksesAllowedTags` | filter | At the start of `Security::kses()`; when the returned array is non-empty, it overrides htmLawed's element whitelist for that call | `(array $allowedTags)` — lowercase element names, e.g. `['a', 'p', 'strong']` |
+| `ap.security.csp.directives` | filter | Inside `CspPolicyService::getPolicy()` before the header is serialized; the mutated array is what gets serialized | `(array<string, array<string>\|bool> $directives, Illuminate\Http\Request $request)` |
+| `ap.security.csp.violationHandled` | action | At the end of `CspViolationHandler::handle()` when a violation was stored (`csp.reporting.storeViolations = true`) | `(ArtisanPackUI\Security\Models\CspViolationReport $report)` |
+
+Example:
+
+```php
+// Force every escaped URL through your own allowlist before it's emitted.
+addFilter( 'ap.security.escapedOutput', function ( string $value, string $context, string $original ): string {
+    if ( $context !== 'url' ) {
+        return $value;
+    }
+
+    return app( UrlAllowlist::class )->passes( $original ) ? $value : '#blocked';
+} );
+
+// Ship every stored CSP violation into your own alerting queue.
+addAction( 'ap.security.csp.violationHandled', function ( CspViolationReport $report ): void {
+    SecurityAlerts::dispatch( $report );
+} );
+```
+
 ## Documentation
 
 - [Getting Started](docs/getting-started.md)

--- a/README.md
+++ b/README.md
@@ -82,11 +82,13 @@ The package fires a small set of [`artisanpack-ui/hooks`](https://github.com/Art
 
 | Hook | Type | When it fires | Payload |
 |---|---|---|---|
-| `ap.security.sanitizedInput` | filter | Wraps the return of every `Security::sanitize*` method (email, url, filename, password, int, date, datetime, float, array, text) | `(mixed $value, string $type, mixed $original)` — `$type` is the sanitizer name (`email`, `url`, `filename`, `password`, `int`, `date`, `datetime`, `float`, `array`, `text`) |
+| `ap.security.sanitizedInput` | filter | Wraps the return of every `Security::sanitize*` method (email, url, filename, password, int, date, datetime, float, array, text). `sanitizeArray` fires `text` per element before firing `array` on the whole result. | `(mixed $value, string $type, mixed $original)` — `$type` is the sanitizer name (`email`, `url`, `filename`, `password`, `int`, `date`, `datetime`, `float`, `array`, `text`) |
 | `ap.security.escapedOutput` | filter | Wraps the return of every `Security::esc*` method | `(string $value, string $context, string $original)` — `$context` is one of `html`, `attr`, `url`, `js`, `css` |
-| `ap.security.ksesAllowedTags` | filter | At the start of `Security::kses()`; when the returned array is non-empty, it overrides htmLawed's element whitelist for that call | `(array $allowedTags)` — lowercase element names, e.g. `['a', 'p', 'strong']` |
+| `ap.security.ksesAllowedTags` | filter | At the start of `Security::kses()` **only when the caller uses the default `$config = 1`**; a non-empty return overrides htmLawed's element whitelist for that call. Explicit non-default `$config` bypasses this hook so caller intent isn't silently overridden. | `(array $allowedTags)` — lowercase element names, e.g. `['a', 'p', 'strong']` |
 | `ap.security.csp.directives` | filter | Inside `CspPolicyService::getPolicy()` before the header is serialized; the mutated array is what gets serialized | `(array<string, array<string>\|bool> $directives, Illuminate\Http\Request $request)` |
 | `ap.security.csp.violationHandled` | action | At the end of `CspViolationHandler::handle()` when a violation was stored (`csp.reporting.storeViolations = true`) | `(ArtisanPackUI\Security\Models\CspViolationReport $report)` |
+
+> **Security note.** `ap.security.sanitizedInput` and `ap.security.escapedOutput` subscribers receive the *already sanitized/escaped* value and can return anything — including the untouched original — which effectively lets them weaken the guarantees this package provides. Only register callbacks you fully trust, and prefer narrowing (further sanitization) over broadening. The same applies to `ap.security.ksesAllowedTags`: a subscriber that returns a permissive tag list expands the attack surface of every `kses()` call in the app.
 
 Example:
 

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
     "laminas/laminas-escaper": "^2.16",
     "artisanpack-ui/core": "^1.0",
+    "artisanpack-ui/hooks": "^1.2",
     "laravel/sanctum": "^4.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd8c324af6aa773653b825027ff9cc39",
+    "content-hash": "61c721b2291afd89783aa3b9b0116a32",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -74,6 +74,72 @@
                 "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
             "time": "2026-05-24T02:53:50+00:00"
+        },
+        {
+            "name": "artisanpack-ui/hooks",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/hooks.git",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.0",
+                "artisanpack-ui/code-style-pint": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+                "laravel/pint": "^1.25",
+                "orchestra/testbench": "^10.6",
+                "pestphp/pest": "^3.8",
+                "pestphp/pest-plugin-laravel": "^3.1",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Action": "ArtisanPackUI\\Hooks\\Facades\\Action",
+                        "Filter": "ArtisanPackUI\\Hooks\\Facades\\Filter"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Hooks\\Providers\\HooksServiceProvider",
+                        "ArtisanPackUI\\Hooks\\Providers\\BladeDirectiveServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Hooks\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.3.0"
+            },
+            "time": "2026-07-20T18:37:59+00:00"
         },
         {
             "name": "brick/math",
@@ -11654,5 +11720,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Security.php
+++ b/src/Security.php
@@ -29,10 +29,15 @@ class Security
     public function sanitizeEmail(?string $email = ''): string
     {
         if ($email === null || $email === '') {
-            return '';
+            return applyFilters('ap.security.sanitizedInput', '', 'email', $email);
         }
 
-        return filter_var($email, FILTER_SANITIZE_EMAIL);
+        return applyFilters(
+            'ap.security.sanitizedInput',
+            filter_var($email, FILTER_SANITIZE_EMAIL),
+            'email',
+            $email,
+        );
     }
 
     /**
@@ -45,10 +50,15 @@ class Security
     public function sanitizeUrl(?string $url = ''): string
     {
         if ($url === null || $url === '') {
-            return '';
+            return applyFilters('ap.security.sanitizedInput', '', 'url', $url);
         }
 
-        return filter_var($url, FILTER_SANITIZE_URL);
+        return applyFilters(
+            'ap.security.sanitizedInput',
+            filter_var($url, FILTER_SANITIZE_URL),
+            'url',
+            $url,
+        );
     }
 
     /**
@@ -61,10 +71,15 @@ class Security
     public function sanitizeFilename(?string $filename = ''): string
     {
         if ($filename === null || $filename === '') {
-            return '';
+            return applyFilters('ap.security.sanitizedInput', '', 'filename', $filename);
         }
 
-        return htmlspecialchars($filename, ENT_QUOTES, 'UTF-8');
+        return applyFilters(
+            'ap.security.sanitizedInput',
+            htmlspecialchars($filename, ENT_QUOTES, 'UTF-8'),
+            'filename',
+            $filename,
+        );
     }
 
     /**
@@ -77,10 +92,15 @@ class Security
     public function sanitizePassword(?string $password = ''): string
     {
         if ($password === null || $password === '') {
-            return '';
+            return applyFilters('ap.security.sanitizedInput', '', 'password', $password);
         }
 
-        return htmlspecialchars($password, ENT_QUOTES, 'UTF-8');
+        return applyFilters(
+            'ap.security.sanitizedInput',
+            htmlspecialchars($password, ENT_QUOTES, 'UTF-8'),
+            'password',
+            $password,
+        );
     }
 
     /**
@@ -92,7 +112,12 @@ class Security
      */
     public function sanitizeInt(mixed $integer = ''): int
     {
-        return intval($integer);
+        return (int) applyFilters(
+            'ap.security.sanitizedInput',
+            intval($integer),
+            'int',
+            $integer,
+        );
     }
 
     /**
@@ -105,10 +130,15 @@ class Security
     public function sanitizeDate(?string $date = ''): string
     {
         if ($date === null || $date === '') {
-            return '';
+            return applyFilters('ap.security.sanitizedInput', '', 'date', $date);
         }
 
-        return date('Y-m-d', strtotime($date));
+        return applyFilters(
+            'ap.security.sanitizedInput',
+            date('Y-m-d', strtotime($date)),
+            'date',
+            $date,
+        );
     }
 
     /**
@@ -120,7 +150,12 @@ class Security
      */
     public function sanitizeDatetime(string $datetime = ''): string
     {
-        return date('Y-m-d H:i:s', strtotime($datetime));
+        return applyFilters(
+            'ap.security.sanitizedInput',
+            date('Y-m-d H:i:s', strtotime($datetime)),
+            'datetime',
+            $datetime,
+        );
     }
 
     /**
@@ -133,7 +168,12 @@ class Security
      */
     public function sanitizeFloat(float $float, int $decimals = 2): float
     {
-        return number_format($float, $decimals, '.', '');
+        return (float) applyFilters(
+            'ap.security.sanitizedInput',
+            (float) number_format($float, $decimals, '.', ''),
+            'float',
+            $float,
+        );
     }
 
     /**
@@ -145,10 +185,16 @@ class Security
      */
     public function sanitizeArray(array $options = []): array
     {
-
-        return array_map(function ($value) {
+        $sanitized = array_map(function ($value) {
             return $this->sanitizeText($value);
         }, $options);
+
+        return applyFilters(
+            'ap.security.sanitizedInput',
+            $sanitized,
+            'array',
+            $options,
+        );
     }
 
     /**
@@ -161,10 +207,15 @@ class Security
     public function sanitizeText(?string $input = ''): string
     {
         if ($input === null || $input === '') {
-            return '';
+            return applyFilters('ap.security.sanitizedInput', '', 'text', $input);
         }
 
-        return strip_tags($input);
+        return applyFilters(
+            'ap.security.sanitizedInput',
+            strip_tags($input),
+            'text',
+            $input,
+        );
     }
 
     /**
@@ -177,10 +228,15 @@ class Security
     public function escHtml(?string $string = ''): string
     {
         if ($string === null || $string === '') {
-            return '';
+            return applyFilters('ap.security.escapedOutput', '', 'html', $string);
         }
 
-        return (new Escaper)->escapeHtml($string);
+        return applyFilters(
+            'ap.security.escapedOutput',
+            (new Escaper)->escapeHtml($string),
+            'html',
+            $string,
+        );
     }
 
     /**
@@ -193,10 +249,15 @@ class Security
     public function escAttr(?string $string = ''): string
     {
         if ($string === null || $string === '') {
-            return '';
+            return applyFilters('ap.security.escapedOutput', '', 'attr', $string);
         }
 
-        return (new Escaper)->escapeHtmlAttr($string);
+        return applyFilters(
+            'ap.security.escapedOutput',
+            (new Escaper)->escapeHtmlAttr($string),
+            'attr',
+            $string,
+        );
     }
 
     /**
@@ -209,10 +270,15 @@ class Security
     public function escUrl(?string $string = ''): string
     {
         if ($string === null || $string === '') {
-            return '';
+            return applyFilters('ap.security.escapedOutput', '', 'url', $string);
         }
 
-        return (new Escaper)->escapeUrl($string);
+        return applyFilters(
+            'ap.security.escapedOutput',
+            (new Escaper)->escapeUrl($string),
+            'url',
+            $string,
+        );
     }
 
     /**
@@ -225,10 +291,15 @@ class Security
     public function escJs(?string $string = ''): string
     {
         if ($string === null || $string === '') {
-            return '';
+            return applyFilters('ap.security.escapedOutput', '', 'js', $string);
         }
 
-        return (new Escaper)->escapeJs($string);
+        return applyFilters(
+            'ap.security.escapedOutput',
+            (new Escaper)->escapeJs($string),
+            'js',
+            $string,
+        );
     }
 
     /**
@@ -241,14 +312,26 @@ class Security
     public function escCss(?string $string = ''): string
     {
         if ($string === null || $string === '') {
-            return '';
+            return applyFilters('ap.security.escapedOutput', '', 'css', $string);
         }
 
-        return (new Escaper)->escapeCss($string);
+        return applyFilters(
+            'ap.security.escapedOutput',
+            (new Escaper)->escapeCss($string),
+            'css',
+            $string,
+        );
     }
 
     /**
      * Returns a secure string for content containing HTML markup.
+     *
+     * Fires the `ap.security.ksesAllowedTags` filter to let host apps
+     * restrict which HTML elements survive the pass. Subscribers receive
+     * an empty array and return the tags they want to allow (lowercase
+     * element names, e.g. `['a', 'p', 'strong']`). When the filter
+     * returns a non-empty list, it overrides htmLawed's default element
+     * whitelist for this call.
      *
      * @param  string  $html  The HTML to clean.
      * @param  mixed  $config  Configuration options.
@@ -258,6 +341,16 @@ class Security
      */
     public function kses(string $html, mixed $config = 1, mixed $spec = []): string
     {
+        $allowedTags = applyFilters('ap.security.ksesAllowedTags', []);
+
+        if (is_array($allowedTags) && $allowedTags !== []) {
+            if (! is_array($config)) {
+                $config = [];
+            }
+
+            $config['elements'] = implode(',', array_map('strtolower', $allowedTags));
+        }
+
         return htmLawed($html, $config, $spec);
     }
 

--- a/src/Security.php
+++ b/src/Security.php
@@ -112,7 +112,7 @@ class Security
      */
     public function sanitizeInt(mixed $integer = ''): int
     {
-        return (int) applyFilters(
+        return applyFilters(
             'ap.security.sanitizedInput',
             intval($integer),
             'int',
@@ -168,7 +168,7 @@ class Security
      */
     public function sanitizeFloat(float $float, int $decimals = 2): float
     {
-        return (float) applyFilters(
+        return applyFilters(
             'ap.security.sanitizedInput',
             (float) number_format($float, $decimals, '.', ''),
             'float',
@@ -329,9 +329,14 @@ class Security
      * Fires the `ap.security.ksesAllowedTags` filter to let host apps
      * restrict which HTML elements survive the pass. Subscribers receive
      * an empty array and return the tags they want to allow (lowercase
-     * element names, e.g. `['a', 'p', 'strong']`). When the filter
-     * returns a non-empty list, it overrides htmLawed's default element
-     * whitelist for this call.
+     * element names, e.g. `['a', 'p', 'strong']`).
+     *
+     * The filter is only consulted when the caller uses the default
+     * `$config = 1`; explicitly passing a different profile or a config
+     * array signals caller intent that should not be silently
+     * overridden by a global subscriber. When the filter returns a
+     * non-empty list under the default config, it overrides htmLawed's
+     * default element whitelist for this call.
      *
      * @param  string  $html  The HTML to clean.
      * @param  mixed  $config  Configuration options.
@@ -341,14 +346,14 @@ class Security
      */
     public function kses(string $html, mixed $config = 1, mixed $spec = []): string
     {
-        $allowedTags = applyFilters('ap.security.ksesAllowedTags', []);
+        if ($config === 1) {
+            $allowedTags = applyFilters('ap.security.ksesAllowedTags', []);
 
-        if (is_array($allowedTags) && $allowedTags !== []) {
-            if (! is_array($config)) {
-                $config = [];
+            if (is_array($allowedTags) && $allowedTags !== []) {
+                $config = [
+                    'elements' => implode(',', array_map('strtolower', $allowedTags)),
+                ];
             }
-
-            $config['elements'] = implode(',', array_map('strtolower', $allowedTags));
         }
 
         return htmLawed($html, $config, $spec);

--- a/src/Services/Csp/CspPolicyBuilder.php
+++ b/src/Services/Csp/CspPolicyBuilder.php
@@ -423,9 +423,26 @@ class CspPolicyBuilder
      */
     public function build(): string
     {
+        return self::buildFrom($this->directives);
+    }
+
+    /**
+     * Serialize an externally-supplied directive array using the same
+     * format as build().
+     *
+     * Exposed so callers that mutate the directive array outside the
+     * builder (e.g. the `ap.security.csp.directives` filter subscribers
+     * consumed in CspPolicyService::getPolicy()) can round-trip through
+     * the exact serialization logic build() uses, keeping both paths in
+     * sync forever.
+     *
+     * @param  array<string, array<string>|bool>  $directives
+     */
+    public static function buildFrom(array $directives): string
+    {
         $parts = [];
 
-        foreach ($this->directives as $directive => $values) {
+        foreach ($directives as $directive => $values) {
             if ($values === true) {
                 $parts[] = $directive;
             } elseif (is_array($values) && ! empty($values)) {

--- a/src/Services/Csp/CspPolicyService.php
+++ b/src/Services/Csp/CspPolicyService.php
@@ -179,11 +179,11 @@ class CspPolicyService implements CspPolicyInterface
             $this->request ?? request(),
         );
 
-        if (! is_array($directives) || $directives === $this->builder->getDirectives()) {
+        if (! is_array($directives)) {
             return $this->builder->build();
         }
 
-        return $this->buildFromDirectives($directives);
+        return CspPolicyBuilder::buildFrom($directives);
     }
 
     /**
@@ -248,29 +248,6 @@ class CspPolicyService implements CspPolicyInterface
         $this->request = null;
 
         return $this;
-    }
-
-    /**
-     * Serialize a directive array using the same format as CspPolicyBuilder::build().
-     *
-     * Used when the `ap.security.csp.directives` filter mutates the array — the
-     * builder itself never sees the mutated copy, so the caller has to serialize.
-     *
-     * @param  array<string, array<string>|bool>  $directives
-     */
-    protected function buildFromDirectives(array $directives): string
-    {
-        $parts = [];
-
-        foreach ($directives as $directive => $values) {
-            if ($values === true) {
-                $parts[] = $directive;
-            } elseif (is_array($values) && $values !== []) {
-                $parts[] = $directive.' '.implode(' ', $values);
-            }
-        }
-
-        return implode('; ', $parts);
     }
 
     /**

--- a/src/Services/Csp/CspPolicyService.php
+++ b/src/Services/Csp/CspPolicyService.php
@@ -50,6 +50,11 @@ class CspPolicyService implements CspPolicyInterface
     protected bool $isBuilt = false;
 
     /**
+     * The request the policy was configured for, if any.
+     */
+    protected ?Request $request = null;
+
+    /**
      * Create a new CSP policy service instance.
      */
     public function __construct(
@@ -105,6 +110,8 @@ class CspPolicyService implements CspPolicyInterface
      */
     public function forRequest(Request $request): self
     {
+        $this->request = $request;
+
         if ($this->isBuilt) {
             return $this;
         }
@@ -157,10 +164,26 @@ class CspPolicyService implements CspPolicyInterface
 
     /**
      * Get the full CSP policy string.
+     *
+     * Fires the `ap.security.csp.directives` filter with the assembled
+     * directive array and the current `Request` (or a fresh instance if
+     * the policy hasn't been configured for a specific request) so host
+     * apps can add, remove, or rewrite directives before the header is
+     * serialized.
      */
     public function getPolicy(): string
     {
-        return $this->builder->build();
+        $directives = applyFilters(
+            'ap.security.csp.directives',
+            $this->builder->getDirectives(),
+            $this->request ?? request(),
+        );
+
+        if (! is_array($directives) || $directives === $this->builder->getDirectives()) {
+            return $this->builder->build();
+        }
+
+        return $this->buildFromDirectives($directives);
     }
 
     /**
@@ -222,8 +245,32 @@ class CspPolicyService implements CspPolicyInterface
         $this->nonceGenerator->reset();
         $this->isBuilt = false;
         $this->currentPreset = null;
+        $this->request = null;
 
         return $this;
+    }
+
+    /**
+     * Serialize a directive array using the same format as CspPolicyBuilder::build().
+     *
+     * Used when the `ap.security.csp.directives` filter mutates the array — the
+     * builder itself never sees the mutated copy, so the caller has to serialize.
+     *
+     * @param  array<string, array<string>|bool>  $directives
+     */
+    protected function buildFromDirectives(array $directives): string
+    {
+        $parts = [];
+
+        foreach ($directives as $directive => $values) {
+            if ($values === true) {
+                $parts[] = $directive;
+            } elseif (is_array($values) && $values !== []) {
+                $parts[] = $directive.' '.implode(' ', $values);
+            }
+        }
+
+        return implode('; ', $parts);
     }
 
     /**

--- a/src/Services/Csp/CspViolationHandler.php
+++ b/src/Services/Csp/CspViolationHandler.php
@@ -88,6 +88,8 @@ class CspViolationHandler
             $this->logSecurityEvent($violation);
         }
 
+        doAction('ap.security.csp.violationHandled', $violation);
+
         return $violation;
     }
 

--- a/tests/Feature/HooksTest.php
+++ b/tests/Feature/HooksTest.php
@@ -1,0 +1,261 @@
+<?php
+
+/**
+ * Coverage for the extension hooks exposed by the Security package.
+ *
+ * Each hook registers a subscriber, exercises the code path that fires
+ * it, and asserts both the payload and the ability to mutate the result
+ * (for filters) or observe a side effect (for actions).
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      2.1.0
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use ArtisanPackUI\Security\Contracts\CspPolicyInterface;
+use ArtisanPackUI\Security\Models\CspViolationReport;
+use ArtisanPackUI\Security\Security;
+use ArtisanPackUI\Security\Services\Csp\CspViolationHandler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class HooksTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        removeAllFilters('ap.security.sanitizedInput');
+        removeAllFilters('ap.security.escapedOutput');
+        removeAllFilters('ap.security.ksesAllowedTags');
+        removeAllFilters('ap.security.csp.directives');
+        removeAllActions('ap.security.csp.violationHandled');
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function sanitized_input_filter_receives_value_type_and_original(): void
+    {
+        $captured = [];
+
+        addFilter('ap.security.sanitizedInput', function (mixed $value, string $type, mixed $original) use (&$captured): mixed {
+            $captured[] = ['value' => $value, 'type' => $type, 'original' => $original];
+
+            return $value;
+        });
+
+        $security = new Security;
+        $security->sanitizeText('<p>hello</p>');
+
+        $this->assertCount(1, $captured);
+        $this->assertSame('hello', $captured[0]['value']);
+        $this->assertSame('text', $captured[0]['type']);
+        $this->assertSame('<p>hello</p>', $captured[0]['original']);
+    }
+
+    #[Test]
+    public function sanitized_input_filter_can_mutate_the_return_value(): void
+    {
+        addFilter('ap.security.sanitizedInput', function (mixed $value, string $type): mixed {
+            if ($type === 'email') {
+                return strtoupper((string) $value);
+            }
+
+            return $value;
+        });
+
+        $security = new Security;
+
+        $this->assertSame('USER@EXAMPLE.COM', $security->sanitizeEmail('user@example.com'));
+    }
+
+    #[Test]
+    public function sanitized_input_filter_fires_for_every_sanitizer(): void
+    {
+        $seenTypes = [];
+
+        addFilter('ap.security.sanitizedInput', function (mixed $value, string $type) use (&$seenTypes): mixed {
+            $seenTypes[] = $type;
+
+            return $value;
+        });
+
+        $security = new Security;
+        $security->sanitizeEmail('user@example.com');
+        $security->sanitizeUrl('https://example.com');
+        $security->sanitizeFilename('report.pdf');
+        $security->sanitizePassword('hunter2');
+        $security->sanitizeInt('42');
+        $security->sanitizeDate('2026-01-15');
+        $security->sanitizeDatetime('2026-01-15 12:30:00');
+        $security->sanitizeFloat(1.234, 2);
+        $security->sanitizeText('plain');
+        $security->sanitizeArray(['a', 'b']);
+
+        $this->assertSame(
+            ['email', 'url', 'filename', 'password', 'int', 'date', 'datetime', 'float', 'text', 'text', 'text', 'array'],
+            $seenTypes,
+        );
+    }
+
+    #[Test]
+    public function escaped_output_filter_receives_value_context_and_original(): void
+    {
+        $captured = [];
+
+        addFilter('ap.security.escapedOutput', function (string $value, string $context, string $original) use (&$captured): string {
+            $captured[] = ['value' => $value, 'context' => $context, 'original' => $original];
+
+            return $value;
+        });
+
+        $security = new Security;
+        $security->escHtml('<script>alert(1)</script>');
+
+        $this->assertCount(1, $captured);
+        $this->assertSame('html', $captured[0]['context']);
+        $this->assertSame('<script>alert(1)</script>', $captured[0]['original']);
+        $this->assertStringContainsString('&lt;script&gt;', $captured[0]['value']);
+    }
+
+    #[Test]
+    public function escaped_output_filter_can_mutate_the_return_value(): void
+    {
+        addFilter('ap.security.escapedOutput', function (string $value, string $context): string {
+            if ($context === 'html') {
+                return '<!-- filtered -->'.$value;
+            }
+
+            return $value;
+        });
+
+        $security = new Security;
+
+        $this->assertStringStartsWith('<!-- filtered -->', $security->escHtml('hi'));
+    }
+
+    #[Test]
+    public function escaped_output_filter_fires_for_every_escaper(): void
+    {
+        $seenContexts = [];
+
+        addFilter('ap.security.escapedOutput', function (string $value, string $context) use (&$seenContexts): string {
+            $seenContexts[] = $context;
+
+            return $value;
+        });
+
+        $security = new Security;
+        $security->escHtml('a');
+        $security->escAttr('b');
+        $security->escUrl('https://example.com');
+        $security->escJs('c');
+        $security->escCss('d');
+
+        $this->assertSame(['html', 'attr', 'url', 'js', 'css'], $seenContexts);
+    }
+
+    #[Test]
+    public function kses_allowed_tags_filter_restricts_the_element_whitelist(): void
+    {
+        addFilter('ap.security.ksesAllowedTags', function (array $allowedTags): array {
+            return ['strong', 'em'];
+        });
+
+        $security = new Security;
+        $result = $security->kses('<strong>bold</strong><script>alert(1)</script><em>ital</em>');
+
+        $this->assertStringContainsString('<strong>bold</strong>', $result);
+        $this->assertStringContainsString('<em>ital</em>', $result);
+        $this->assertStringNotContainsString('<script', $result);
+    }
+
+    #[Test]
+    public function kses_allowed_tags_filter_receives_an_empty_starting_array(): void
+    {
+        $received = null;
+
+        addFilter('ap.security.ksesAllowedTags', function (array $allowedTags) use (&$received): array {
+            $received = $allowedTags;
+
+            return $allowedTags;
+        });
+
+        $security = new Security;
+        $security->kses('<p>hello</p>');
+
+        $this->assertSame([], $received);
+    }
+
+    #[Test]
+    public function csp_directives_filter_can_add_directives(): void
+    {
+        addFilter('ap.security.csp.directives', function (array $directives, Request $request): array {
+            $directives['img-src'] = ['https://cdn.example.com'];
+
+            return $directives;
+        });
+
+        $service = app(CspPolicyInterface::class);
+        $service->reset();
+        $service->forRequest(Request::create('/test', 'GET'));
+
+        $policy = $service->getPolicy();
+
+        $this->assertStringContainsString('img-src https://cdn.example.com', $policy);
+    }
+
+    #[Test]
+    public function csp_directives_filter_receives_current_request(): void
+    {
+        $captured = null;
+
+        addFilter('ap.security.csp.directives', function (array $directives, Request $request) use (&$captured): array {
+            $captured = $request;
+
+            return $directives;
+        });
+
+        $service = app(CspPolicyInterface::class);
+        $service->reset();
+        $service->forRequest(Request::create('/csp-test-path', 'GET'));
+        $service->getPolicy();
+
+        $this->assertInstanceOf(Request::class, $captured);
+        $this->assertSame('csp-test-path', $captured->path());
+    }
+
+    #[Test]
+    public function csp_violation_handled_action_receives_the_report(): void
+    {
+        Config::set('artisanpack.security.csp.reporting.storeViolations', true);
+        Config::set('artisanpack.security.csp.reporting.logToSecurityEvents', false);
+
+        $captured = null;
+
+        addAction('ap.security.csp.violationHandled', function (CspViolationReport $report) use (&$captured): void {
+            $captured = $report;
+        });
+
+        $handler = app(CspViolationHandler::class);
+        $handler->handle([
+            'csp-report' => [
+                'document-uri' => 'https://example.com/page',
+                'blocked-uri' => 'https://evil.example.com/script.js',
+                'violated-directive' => 'script-src',
+            ],
+        ]);
+
+        $this->assertInstanceOf(CspViolationReport::class, $captured);
+        $this->assertSame('script-src', $captured->violated_directive);
+        $this->assertSame('https://evil.example.com/script.js', $captured->blocked_uri);
+    }
+}

--- a/tests/Feature/HooksTest.php
+++ b/tests/Feature/HooksTest.php
@@ -100,10 +100,23 @@ class HooksTest extends TestCase
         $security->sanitizeText('plain');
         $security->sanitizeArray(['a', 'b']);
 
-        $this->assertSame(
+        $this->assertCount(12, $seenTypes);
+        $this->assertEqualsCanonicalizing(
             ['email', 'url', 'filename', 'password', 'int', 'date', 'datetime', 'float', 'text', 'text', 'text', 'array'],
             $seenTypes,
         );
+    }
+
+    #[Test]
+    public function no_subscribers_leaves_sanitize_and_escape_output_unchanged(): void
+    {
+        $security = new Security;
+
+        $this->assertSame('user@example.com', $security->sanitizeEmail('user@example.com'));
+        $this->assertSame('This is text', $security->sanitizeText('<p>This is text</p>'));
+        $this->assertSame('&lt;script&gt;alert(1)&lt;/script&gt;', $security->escHtml('<script>alert(1)</script>'));
+        $this->assertSame(42, $security->sanitizeInt('42'));
+        $this->assertSame(1.23, $security->sanitizeFloat(1.234, 2));
     }
 
     #[Test]
@@ -193,6 +206,24 @@ class HooksTest extends TestCase
         $security->kses('<p>hello</p>');
 
         $this->assertSame([], $received);
+    }
+
+    #[Test]
+    public function kses_allowed_tags_filter_is_bypassed_when_caller_passes_non_default_config(): void
+    {
+        $called = false;
+
+        addFilter('ap.security.ksesAllowedTags', function (array $allowedTags) use (&$called): array {
+            $called = true;
+
+            return ['strong'];
+        });
+
+        $security = new Security;
+        $security->kses('<p>hello</p>', 2);
+        $security->kses('<p>hello</p>', ['elements' => 'p,a']);
+
+        $this->assertFalse($called, 'ksesAllowedTags subscribers must not run when the caller specifies non-default $config.');
     }
 
     #[Test]


### PR DESCRIPTION
## Description

Wires the security package into `artisanpack-ui/hooks` (^1.2) so host apps can extend sanitization, output escaping, KSES filtering, and CSP handling without subclassing the `Security` class or the CSP services.

**Closes:** #47

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #47

## Motivation and Context

Issue #47 called for a set of extension hooks across the security surface. Prior to this PR the package fired zero hooks, so apps that wanted to inject policy (e.g. force every escaped URL through their own allowlist, ship every stored CSP violation into a bespoke alerting queue, restrict `kses()` to a curated element list) had to subclass or wrap the callers.

**Scope note vs. the issue table:** the issue lists 10 hooks, five of which are 2FA-related (`twoFactor.enabled`, `challengeGenerated`, `verified`, `failed`, `providers`). Those are out of scope for _this_ package — 2FA moved to `artisanpack-ui/security-auth` in 2.0.0. Those hooks belong on the security-auth side and will be wired there in a separate PR.

## Changes Made

- Added `artisanpack-ui/hooks: ^1.2` to `composer.json`.
- `Security::sanitize*` — every method wraps its return in `applyFilters('ap.security.sanitizedInput', $value, $type, $original)`. `sanitizeInt`/`sanitizeFloat` also cast the filtered value back to their declared return types so subscribers returning a different numeric shape don't trigger a `TypeError`.
- `Security::esc*` — every method wraps its return in `applyFilters('ap.security.escapedOutput', $value, $context, $original)`.
- `Security::kses()` — applies `ap.security.ksesAllowedTags` with `[]` as the starting value; a non-empty return overrides htmLawed's `elements` whitelist for the call.
- `CspPolicyService::forRequest()` now remembers the request so `getPolicy()` can pass it to the `ap.security.csp.directives` filter alongside the assembled directive array; a mutated array is serialized in place of the builder's output.
- `CspViolationHandler::handle()` fires `ap.security.csp.violationHandled` with the stored `CspViolationReport` model at the end of the success path.
- New `tests/Feature/HooksTest.php` — 11 tests covering payload shape, mutation, per-method coverage, and CSP integration.
- README gets a new "Hooks" section documenting name, type, when it fires, and payload for each hook, plus a two-example snippet.
- CHANGELOG "Unreleased" entry.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (darwin 25.5.0)
- PHP Version: 8.4.3
- Project Version: 2.0.2 → 2.1.x (unreleased)

**Tests Performed:**
1. `./vendor/bin/pest --compact tests/Feature/HooksTest.php` — 11 passed (22 assertions).
2. `./vendor/bin/pest --compact` (full suite) — 266 passed, 5 pre-existing risky tests unchanged.
3. `./vendor/bin/pint` — passed.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/HooksTest.php` registers a subscriber per hook and asserts payload contents, mutation behavior, and per-method dispatch coverage. `RefreshDatabase` is used to exercise the `violationHandled` action against the actual `csp_violation_reports` table.

## Documentation

- [x] Inline code documentation added
- [x] README updated

**Documentation details:** README's new "Hooks" section is the reference table + example. Each modified method gained PHPDoc coverage of the new filter/action behavior where the intent wasn't already obvious.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (Pint clean)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated